### PR TITLE
Use NETStandard 1.0 to provide more support

### DIFF
--- a/ConfigureAwait/ConfigureAwait.csproj
+++ b/ConfigureAwait/ConfigureAwait.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <Authors>Cameron MacFarland, Simon Cropp</Authors>


### PR DESCRIPTION
[PropertyChanged.Fody](https://github.com/Fody/PropertyChanged) uses NETStandard 1.0 as min target, so perhaps **ConfigureAwait.Fody** should do also? In fact, a project I'm working on targets NETStandard 1.3, that's why I couldn't use this awesome package there. So decided to open a PR 😏 

All tests passed, except **ModuleWeaverTests.DecompileGenericMethod**. 
But it also doesn't pass for me if I rollback all the changes.
```
Assert.Equal() Failure
                                  (pos 900)
Expected: ···alname rtspecialname\r\n            instance void  .ctor() cil ···
Actual:   ···alname rtspecialname \r\n            instance void  .ctor() cil···
                                  (pos 900)
```