### PR TITLE
Implemented support for ValueTask

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -7,4 +7,8 @@
   <ItemGroup>
     <ProjectReference Include="..\ConfigureAwait\ConfigureAwait.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+  </ItemGroup>
 </Project>

--- a/AssemblyToProcess/CatchAndFinally.cs
+++ b/AssemblyToProcess/CatchAndFinally.cs
@@ -79,5 +79,81 @@ namespace AssemblyToProcess
                 await Task.Delay(1).ConfigureAwait(false);
             }
         }
+
+#if NETCOREAPP2_0
+        public async Task Catch1_WithValueTask()
+        {
+            try
+            {
+                throw new NotImplementedException();
+            }
+            catch
+            {
+                await new ValueTask(Task.Delay(1));
+            }
+        }
+
+        [ConfigureAwait(false)]
+        public async Task Catch2_WithValueTask()
+        {
+            try
+            {
+                throw new NotImplementedException();
+            }
+            catch
+            {
+                await new ValueTask(Task.Delay(1));
+            }
+        }
+
+        public async Task Catch3_WithValueTask()
+        {
+            try
+            {
+                throw new NotImplementedException();
+            }
+            catch
+            {
+                await new ValueTask(Task.Delay(1)).ConfigureAwait(false);
+            }
+        }
+
+        public async Task Finally1_WithValueTask()
+        {
+            try
+            {
+                throw new NotImplementedException();
+            }
+            finally
+            {
+                await new ValueTask(Task.Delay(1));
+            }
+        }
+
+        [ConfigureAwait(false)]
+        public async Task Finally2_WithValueTask()
+        {
+            try
+            {
+                throw new NotImplementedException();
+            }
+            finally
+            {
+                await new ValueTask(Task.Delay(1));
+            }
+        }
+
+        public async Task Finally3_WithValueTask()
+        {
+            try
+            {
+                throw new NotImplementedException();
+            }
+            finally
+            {
+                await new ValueTask(Task.Delay(1)).ConfigureAwait(false);
+            }
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/ClassWithAttribute.cs
+++ b/AssemblyToProcess/ClassWithAttribute.cs
@@ -31,5 +31,32 @@ namespace AssemblyToProcess
             SynchronizationContext.SetSynchronizationContext(context);
             return await Task.Run(() => 10);
         }
+
+#if NETCOREAPP2_0
+        public async Task AsyncMethod_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Delay(10));
+        }
+
+        public async Task<int> AsyncMethodWithReturn_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Delay(10));
+            return 10;
+        }
+
+        public async Task AsyncGenericMethod_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Run(() => 10));
+        }
+
+        public async Task<int> AsyncGenericMethodWithReturn_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            return await new ValueTask<int>(Task.Run(() => 10));
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/DoNotWeave.cs
+++ b/AssemblyToProcess/DoNotWeave.cs
@@ -31,5 +31,32 @@ namespace AssemblyToProcess
             SynchronizationContext.SetSynchronizationContext(context);
             return await Task.Run(() => 10).ConfigureAwait(true);
         }
+
+#if NETCOREAPP2_0
+        public async Task AsyncMethod_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Delay(10)).ConfigureAwait(true);
+        }
+
+        public async Task<int> AsyncMethodWithReturn_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Delay(10)).ConfigureAwait(true);
+            return 10;
+        }
+
+        public async Task AsyncGenericMethod_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Run(() => 10)).ConfigureAwait(true);
+        }
+
+        public async Task<int> AsyncGenericMethodWithReturn_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            return await new ValueTask<int>(Task.Run(() => 10)).ConfigureAwait(true);
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/Example.cs
+++ b/AssemblyToProcess/Example.cs
@@ -95,5 +95,98 @@ namespace AssemblyToProcess
             var result = await Task.FromResult(new Example()).ConfigureAwait(false);
             return result;
         }
+
+#if NETCOREAPP2_0
+        public async Task AsyncMethod1_WithValueTask()
+        {
+            await new ValueTask(Task.Delay(1));
+        }
+
+        [ConfigureAwait(false)]
+        public async Task AsyncMethod2_WithValueTask()
+        {
+            await new ValueTask(Task.Delay(1));
+        }
+
+        public async Task AsyncMethod3_WithValueTask()
+        {
+            await new ValueTask(Task.Delay(1)).ConfigureAwait(false);
+        }
+
+        public async Task<int> AsyncMethod4_WithValueTask()
+        {
+            var result = await new ValueTask<int>(Task.FromResult(10));
+            return result;
+        }
+
+        [ConfigureAwait(false)]
+        public async Task<int> AsyncMethod5_WithValueTask()
+        {
+            var result = await new ValueTask<int>(Task.FromResult(10));
+            return result;
+        }
+
+        public async Task<int> AsyncMethod6_WithValueTask()
+        {
+            var result = await new ValueTask<int>(Task.FromResult(10)).ConfigureAwait(false);
+            return result;
+        }
+
+        public async Task<int> AsyncMethod7_WithValueTask()
+        {
+            var count = await new ValueTask<int>(Task.FromResult(10));
+            var sum = 0;
+            for (var i = 0; i < count; i++)
+            {
+                await Task.Delay(1);
+                sum += await Task.FromResult(i);
+            }
+            return sum;
+        }
+
+        [ConfigureAwait(false)]
+        public async Task<int> AsyncMethod8_WithValueTask()
+        {
+            var count = await new ValueTask<int>(Task.FromResult(10));
+            var sum = 0;
+            for (var i = 0; i < count; i++)
+            {
+                await new ValueTask(Task.Delay(1));
+                sum += await new ValueTask<int>(Task.FromResult(i));
+            }
+            return sum;
+        }
+
+        public async Task<int> AsyncMethod9_WithValueTask()
+        {
+            var count = await new ValueTask<int>(Task.FromResult(10)).ConfigureAwait(false);
+            var sum = 0;
+            for (var i = 0; i < count; i++)
+            {
+                await new ValueTask(Task.Delay(1)).ConfigureAwait(false);
+                sum += await new ValueTask<int>(Task.FromResult(i)).ConfigureAwait(false);
+            }
+            return sum;
+        }
+
+        public async Task<Example> AsyncMethod10_WithValueTask()
+        {
+            var result = await new ValueTask<Example>(Task.FromResult(new Example()));
+            return result;
+        }
+
+        [ConfigureAwait(false)]
+        public async Task<Example> AsyncMethod11_WithValueTask()
+        {
+            var result = await new ValueTask<Example>(Task.FromResult(new Example()));
+            return result;
+        }
+
+        public async Task<Example> AsyncMethod12_WithValueTask()
+        {
+            var result = await new ValueTask<Example>(Task.FromResult(new Example())).ConfigureAwait(false);
+            return result;
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/GenericIssue.cs
+++ b/AssemblyToProcess/GenericIssue.cs
@@ -11,6 +11,14 @@ namespace AssemblyToProcess
         {
             var item = await itemTask;
         }
+
+#if NETCOREAPP2_0
+        [ConfigureAwait(false)]
+        public async Task Method_WithValueTask(Task<TItem> itemTask)
+        {
+            var item = await new ValueTask<TItem>(itemTask);
+        }
+#endif
     }
 
     sealed class GenericMethod
@@ -20,5 +28,13 @@ namespace AssemblyToProcess
         {
             var item = await itemTask;
         }
+
+#if NETCOREAPP2_0
+        [ConfigureAwait(false)]
+        public async Task Method_WithValueTask<TItem>(Task<TItem> itemTask)
+        {
+            var item = await new ValueTask<TItem>(itemTask);
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/Issue1.cs
+++ b/AssemblyToProcess/Issue1.cs
@@ -15,5 +15,17 @@ namespace AssemblyToProcess
                 await writer.WriteLineAsync(line);
             }
         }
+
+#if NETCOREAPP2_0
+        [ConfigureAwait(false)]
+        async Task WithReaderAndWriter_WithValueTask(TextWriter writer, StreamReader reader)
+        {
+            string line;
+            while ((line = await new ValueTask<string>(reader.ReadLineAsync())) != null)
+            {
+                await new ValueTask(writer.WriteLineAsync(line));
+            }
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/MethodWithAttribute.cs
+++ b/AssemblyToProcess/MethodWithAttribute.cs
@@ -12,5 +12,14 @@ namespace AssemblyToProcess
             SynchronizationContext.SetSynchronizationContext(context);
             await Task.Delay(0);
         }
+
+#if NETCOREAPP2_0
+        [ConfigureAwait(false)]
+        public async Task AsyncMethod_WithValueTask(SynchronizationContext context)
+        {
+            SynchronizationContext.SetSynchronizationContext(context);
+            await new ValueTask(Task.Delay(0));
+        }
+#endif
     }
 }

--- a/AssemblyToProcess/MethodWithUsing.cs
+++ b/AssemblyToProcess/MethodWithUsing.cs
@@ -17,6 +17,20 @@ namespace AssemblyToProcess
             await Task.Delay(0);
             return new MyDisposable();
         }
+
+#if NETCOREAPP2_0
+        [ConfigureAwait(false)]
+        public async Task AsyncMethod_WithValueTask()
+        {
+            using(await new ValueTask<IDisposable>(NewMethod_WithValueTask())){}
+        }
+
+        static async Task<IDisposable> NewMethod_WithValueTask()
+        {
+            await new ValueTask(Task.Delay(0));
+            return new MyDisposable();
+        }
+#endif
     }
 
     public class MyDisposable : IDisposable

--- a/Tests/ModuleWeaverTests.DecompileCatchAndFinally_Debug.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileCatchAndFinally_Debug.approved.txt
@@ -915,6 +915,944 @@ instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.Comp
 IL_0000:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<Catch1_WithValueTask>d__6'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.CatchAndFinally '<>4__this'
+.field private object '<>s__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+int32 V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_4,
+class AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_007f
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldc.i4.0
+IL_0011:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>s__2'
+.try
+{
+IL_0016:  nop
+IL_0017:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_001c:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_001d:  stloc.1
+IL_001e:  ldarg.0
+IL_001f:  ldloc.1
+IL_0020:  stfld      object AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>s__1'
+IL_0025:  ldarg.0
+IL_0026:  ldc.i4.1
+IL_0027:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>s__2'
+IL_002c:  leave.s    IL_002e
+}  // end handler
+IL_002e:  ldarg.0
+IL_002f:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>s__2'
+IL_0034:  stloc.2
+IL_0035:  ldloc.2
+IL_0036:  ldc.i4.1
+IL_0037:  beq.s      IL_003b
+IL_0039:  br.s       IL_00a6
+IL_003b:  nop
+IL_003c:  ldc.i4.1
+IL_003d:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0042:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0047:  stloc.s    V_4
+IL_0049:  ldloca.s   V_4
+IL_004b:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::GetAwaiter()
+IL_0050:  stloc.3
+IL_0051:  ldloca.s   V_3
+IL_0053:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::get_IsCompleted()
+IL_0058:  brtrue.s   IL_009b
+IL_005a:  ldarg.0
+IL_005b:  ldc.i4.0
+IL_005c:  dup
+IL_005d:  stloc.0
+IL_005e:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0063:  ldarg.0
+IL_0064:  ldloc.3
+IL_0065:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>u__1'
+IL_006a:  ldarg.0
+IL_006b:  stloc.s    V_5
+IL_006d:  ldarg.0
+IL_006e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_0073:  ldloca.s   V_3
+IL_0075:  ldloca.s   V_5
+IL_0077:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter,class AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'>(!!0&,
+!!1&)
+IL_007c:  nop
+IL_007d:  leave.s    IL_00dd
+IL_007f:  ldarg.0
+IL_0080:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>u__1'
+IL_0085:  stloc.3
+IL_0086:  ldarg.0
+IL_0087:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>u__1'
+IL_008c:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter
+IL_0092:  ldarg.0
+IL_0093:  ldc.i4.m1
+IL_0094:  dup
+IL_0095:  stloc.0
+IL_0096:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_009b:  ldloca.s   V_3
+IL_009d:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::GetResult()
+IL_00a2:  nop
+IL_00a3:  nop
+IL_00a4:  br.s       IL_00a6
+IL_00a6:  ldarg.0
+IL_00a7:  ldnull
+IL_00a8:  stfld      object AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>s__1'
+IL_00ad:  leave.s    IL_00c9
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00af:  stloc.s    V_6
+IL_00b1:  ldarg.0
+IL_00b2:  ldc.i4.s   -2
+IL_00b4:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_00b9:  ldarg.0
+IL_00ba:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_00bf:  ldloc.s    V_6
+IL_00c1:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00c6:  nop
+IL_00c7:  leave.s    IL_00dd
+}  // end handler
+IL_00c9:  ldarg.0
+IL_00ca:  ldc.i4.s   -2
+IL_00cc:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_00d1:  ldarg.0
+IL_00d2:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_00d7:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00dc:  nop
+IL_00dd:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Catch2_WithValueTask>d__7'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.CatchAndFinally '<>4__this'
+.field private object '<>s__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+int32 V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_3,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_4,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_5,
+class AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7' V_6,
+class [System.Runtime]System.Exception V_7)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_0011
+IL_000c:  br         IL_008c
+IL_0011:  nop
+IL_0012:  ldarg.0
+IL_0013:  ldc.i4.0
+IL_0014:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>s__2'
+.try
+{
+IL_0019:  nop
+IL_001a:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_001f:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0020:  stloc.1
+IL_0021:  ldarg.0
+IL_0022:  ldloc.1
+IL_0023:  stfld      object AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>s__1'
+IL_0028:  ldarg.0
+IL_0029:  ldc.i4.1
+IL_002a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>s__2'
+IL_002f:  leave.s    IL_0031
+}  // end handler
+IL_0031:  ldarg.0
+IL_0032:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>s__2'
+IL_0037:  stloc.2
+IL_0038:  ldloc.2
+IL_0039:  ldc.i4.1
+IL_003a:  beq.s      IL_003e
+IL_003c:  br.s       IL_00b3
+IL_003e:  nop
+IL_003f:  ldc.i4.1
+IL_0040:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0045:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_004a:  stloc.s    V_5
+IL_004c:  ldloca.s   V_5
+IL_004e:  ldc.i4.0
+IL_004f:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0054:  stloc.s    V_4
+IL_0056:  ldloca.s   V_4
+IL_0058:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_005d:  stloc.3
+IL_005e:  ldloca.s   V_3
+IL_0060:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0065:  brtrue.s   IL_00a8
+IL_0067:  ldarg.0
+IL_0068:  ldc.i4.0
+IL_0069:  dup
+IL_006a:  stloc.0
+IL_006b:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_0070:  ldarg.0
+IL_0071:  ldloc.3
+IL_0072:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>u__1'
+IL_0077:  ldarg.0
+IL_0078:  stloc.s    V_6
+IL_007a:  ldarg.0
+IL_007b:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0080:  ldloca.s   V_3
+IL_0082:  ldloca.s   V_6
+IL_0084:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'>(!!0&,
+!!1&)
+IL_0089:  nop
+IL_008a:  leave.s    IL_00ea
+IL_008c:  ldarg.0
+IL_008d:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>u__1'
+IL_0092:  stloc.3
+IL_0093:  ldarg.0
+IL_0094:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>u__1'
+IL_0099:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_009f:  ldarg.0
+IL_00a0:  ldc.i4.m1
+IL_00a1:  dup
+IL_00a2:  stloc.0
+IL_00a3:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_00a8:  ldloca.s   V_3
+IL_00aa:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_00af:  nop
+IL_00b0:  nop
+IL_00b1:  br.s       IL_00b3
+IL_00b3:  ldarg.0
+IL_00b4:  ldnull
+IL_00b5:  stfld      object AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>s__1'
+IL_00ba:  leave.s    IL_00d6
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00bc:  stloc.s    V_7
+IL_00be:  ldarg.0
+IL_00bf:  ldc.i4.s   -2
+IL_00c1:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_00c6:  ldarg.0
+IL_00c7:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_00cc:  ldloc.s    V_7
+IL_00ce:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00d3:  nop
+IL_00d4:  leave.s    IL_00ea
+}  // end handler
+IL_00d6:  ldarg.0
+IL_00d7:  ldc.i4.s   -2
+IL_00d9:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_00de:  ldarg.0
+IL_00df:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_00e4:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00e9:  nop
+IL_00ea:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Catch3_WithValueTask>d__8'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.CatchAndFinally '<>4__this'
+.field private object '<>s__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+int32 V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_4,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_5,
+class AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8' V_6,
+class [System.Runtime]System.Exception V_7)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_0089
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldc.i4.0
+IL_0011:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>s__2'
+.try
+{
+IL_0016:  nop
+IL_0017:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_001c:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_001d:  stloc.1
+IL_001e:  ldarg.0
+IL_001f:  ldloc.1
+IL_0020:  stfld      object AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>s__1'
+IL_0025:  ldarg.0
+IL_0026:  ldc.i4.1
+IL_0027:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>s__2'
+IL_002c:  leave.s    IL_002e
+}  // end handler
+IL_002e:  ldarg.0
+IL_002f:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>s__2'
+IL_0034:  stloc.2
+IL_0035:  ldloc.2
+IL_0036:  ldc.i4.1
+IL_0037:  beq.s      IL_003b
+IL_0039:  br.s       IL_00b0
+IL_003b:  nop
+IL_003c:  ldc.i4.1
+IL_003d:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0042:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0047:  stloc.s    V_4
+IL_0049:  ldloca.s   V_4
+IL_004b:  ldc.i4.0
+IL_004c:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0051:  stloc.s    V_5
+IL_0053:  ldloca.s   V_5
+IL_0055:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_005a:  stloc.3
+IL_005b:  ldloca.s   V_3
+IL_005d:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0062:  brtrue.s   IL_00a5
+IL_0064:  ldarg.0
+IL_0065:  ldc.i4.0
+IL_0066:  dup
+IL_0067:  stloc.0
+IL_0068:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_006d:  ldarg.0
+IL_006e:  ldloc.3
+IL_006f:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>u__1'
+IL_0074:  ldarg.0
+IL_0075:  stloc.s    V_6
+IL_0077:  ldarg.0
+IL_0078:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_007d:  ldloca.s   V_3
+IL_007f:  ldloca.s   V_6
+IL_0081:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'>(!!0&,
+!!1&)
+IL_0086:  nop
+IL_0087:  leave.s    IL_00e7
+IL_0089:  ldarg.0
+IL_008a:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>u__1'
+IL_008f:  stloc.3
+IL_0090:  ldarg.0
+IL_0091:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>u__1'
+IL_0096:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_009c:  ldarg.0
+IL_009d:  ldc.i4.m1
+IL_009e:  dup
+IL_009f:  stloc.0
+IL_00a0:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_00a5:  ldloca.s   V_3
+IL_00a7:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_00ac:  nop
+IL_00ad:  nop
+IL_00ae:  br.s       IL_00b0
+IL_00b0:  ldarg.0
+IL_00b1:  ldnull
+IL_00b2:  stfld      object AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>s__1'
+IL_00b7:  leave.s    IL_00d3
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00b9:  stloc.s    V_7
+IL_00bb:  ldarg.0
+IL_00bc:  ldc.i4.s   -2
+IL_00be:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_00c3:  ldarg.0
+IL_00c4:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_00c9:  ldloc.s    V_7
+IL_00cb:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00d0:  nop
+IL_00d1:  leave.s    IL_00e7
+}  // end handler
+IL_00d3:  ldarg.0
+IL_00d4:  ldc.i4.s   -2
+IL_00d6:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_00db:  ldarg.0
+IL_00dc:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_00e1:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00e6:  nop
+IL_00e7:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Finally1_WithValueTask>d__9'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.CatchAndFinally '<>4__this'
+.field private object '<>s__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+class AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9' V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_0074
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldnull
+IL_0011:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>s__1'
+IL_0016:  ldarg.0
+IL_0017:  ldc.i4.0
+IL_0018:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>s__2'
+.try
+{
+IL_001d:  nop
+IL_001e:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_0023:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0024:  stloc.1
+IL_0025:  ldarg.0
+IL_0026:  ldloc.1
+IL_0027:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>s__1'
+IL_002c:  leave.s    IL_002e
+}  // end handler
+IL_002e:  nop
+IL_002f:  ldc.i4.1
+IL_0030:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0035:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_003a:  stloc.3
+IL_003b:  ldloca.s   V_3
+IL_003d:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::GetAwaiter()
+IL_0042:  stloc.2
+IL_0043:  ldloca.s   V_2
+IL_0045:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::get_IsCompleted()
+IL_004a:  brtrue.s   IL_0090
+IL_004c:  ldarg.0
+IL_004d:  ldc.i4.0
+IL_004e:  dup
+IL_004f:  stloc.0
+IL_0050:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_0055:  ldarg.0
+IL_0056:  ldloc.2
+IL_0057:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>u__1'
+IL_005c:  ldarg.0
+IL_005d:  stloc.s    V_4
+IL_005f:  ldarg.0
+IL_0060:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_0065:  ldloca.s   V_2
+IL_0067:  ldloca.s   V_4
+IL_0069:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter,class AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'>(!!0&,
+!!1&)
+IL_006e:  nop
+IL_006f:  leave      IL_00fc
+IL_0074:  ldarg.0
+IL_0075:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>u__1'
+IL_007a:  stloc.2
+IL_007b:  ldarg.0
+IL_007c:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>u__1'
+IL_0081:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter
+IL_0087:  ldarg.0
+IL_0088:  ldc.i4.m1
+IL_0089:  dup
+IL_008a:  stloc.0
+IL_008b:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_0090:  ldloca.s   V_2
+IL_0092:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::GetResult()
+IL_0097:  nop
+IL_0098:  nop
+IL_0099:  ldarg.0
+IL_009a:  ldfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>s__1'
+IL_009f:  stloc.1
+IL_00a0:  ldloc.1
+IL_00a1:  brfalse.s  IL_00be
+IL_00a3:  ldloc.1
+IL_00a4:  isinst     [System.Runtime]System.Exception
+IL_00a9:  stloc.s    V_5
+IL_00ab:  ldloc.s    V_5
+IL_00ad:  brtrue.s   IL_00b1
+IL_00af:  ldloc.1
+IL_00b0:  throw
+IL_00b1:  ldloc.s    V_5
+IL_00b3:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00b8:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00bd:  nop
+IL_00be:  ldarg.0
+IL_00bf:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>s__2'
+IL_00c4:  pop
+IL_00c5:  ldarg.0
+IL_00c6:  ldnull
+IL_00c7:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>s__1'
+IL_00cc:  leave.s    IL_00e8
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00ce:  stloc.s    V_5
+IL_00d0:  ldarg.0
+IL_00d1:  ldc.i4.s   -2
+IL_00d3:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_00d8:  ldarg.0
+IL_00d9:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_00de:  ldloc.s    V_5
+IL_00e0:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00e5:  nop
+IL_00e6:  leave.s    IL_00fc
+}  // end handler
+IL_00e8:  ldarg.0
+IL_00e9:  ldc.i4.s   -2
+IL_00eb:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_00f0:  ldarg.0
+IL_00f1:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_00f6:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00fb:  nop
+IL_00fc:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Finally2_WithValueTask>d__10'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.CatchAndFinally '<>4__this'
+.field private object '<>s__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_4,
+class AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_007e
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldnull
+IL_0011:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>s__1'
+IL_0016:  ldarg.0
+IL_0017:  ldc.i4.0
+IL_0018:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>s__2'
+.try
+{
+IL_001d:  nop
+IL_001e:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_0023:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0024:  stloc.1
+IL_0025:  ldarg.0
+IL_0026:  ldloc.1
+IL_0027:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>s__1'
+IL_002c:  leave.s    IL_002e
+}  // end handler
+IL_002e:  nop
+IL_002f:  ldc.i4.1
+IL_0030:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0035:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_003a:  stloc.s    V_4
+IL_003c:  ldloca.s   V_4
+IL_003e:  ldc.i4.0
+IL_003f:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0044:  stloc.3
+IL_0045:  ldloca.s   V_3
+IL_0047:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_004c:  stloc.2
+IL_004d:  ldloca.s   V_2
+IL_004f:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0054:  brtrue.s   IL_009a
+IL_0056:  ldarg.0
+IL_0057:  ldc.i4.0
+IL_0058:  dup
+IL_0059:  stloc.0
+IL_005a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_005f:  ldarg.0
+IL_0060:  ldloc.2
+IL_0061:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>u__1'
+IL_0066:  ldarg.0
+IL_0067:  stloc.s    V_5
+IL_0069:  ldarg.0
+IL_006a:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_006f:  ldloca.s   V_2
+IL_0071:  ldloca.s   V_5
+IL_0073:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'>(!!0&,
+!!1&)
+IL_0078:  nop
+IL_0079:  leave      IL_0106
+IL_007e:  ldarg.0
+IL_007f:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>u__1'
+IL_0084:  stloc.2
+IL_0085:  ldarg.0
+IL_0086:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>u__1'
+IL_008b:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0091:  ldarg.0
+IL_0092:  ldc.i4.m1
+IL_0093:  dup
+IL_0094:  stloc.0
+IL_0095:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_009a:  ldloca.s   V_2
+IL_009c:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_00a1:  nop
+IL_00a2:  nop
+IL_00a3:  ldarg.0
+IL_00a4:  ldfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>s__1'
+IL_00a9:  stloc.1
+IL_00aa:  ldloc.1
+IL_00ab:  brfalse.s  IL_00c8
+IL_00ad:  ldloc.1
+IL_00ae:  isinst     [System.Runtime]System.Exception
+IL_00b3:  stloc.s    V_6
+IL_00b5:  ldloc.s    V_6
+IL_00b7:  brtrue.s   IL_00bb
+IL_00b9:  ldloc.1
+IL_00ba:  throw
+IL_00bb:  ldloc.s    V_6
+IL_00bd:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00c2:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00c7:  nop
+IL_00c8:  ldarg.0
+IL_00c9:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>s__2'
+IL_00ce:  pop
+IL_00cf:  ldarg.0
+IL_00d0:  ldnull
+IL_00d1:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>s__1'
+IL_00d6:  leave.s    IL_00f2
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00d8:  stloc.s    V_6
+IL_00da:  ldarg.0
+IL_00db:  ldc.i4.s   -2
+IL_00dd:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_00e2:  ldarg.0
+IL_00e3:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_00e8:  ldloc.s    V_6
+IL_00ea:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00ef:  nop
+IL_00f0:  leave.s    IL_0106
+}  // end handler
+IL_00f2:  ldarg.0
+IL_00f3:  ldc.i4.s   -2
+IL_00f5:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_00fa:  ldarg.0
+IL_00fb:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_0100:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_0105:  nop
+IL_0106:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Finally3_WithValueTask>d__11'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.CatchAndFinally '<>4__this'
+.field private object '<>s__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_4,
+class AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_007e
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldnull
+IL_0011:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>s__1'
+IL_0016:  ldarg.0
+IL_0017:  ldc.i4.0
+IL_0018:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>s__2'
+.try
+{
+IL_001d:  nop
+IL_001e:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_0023:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0024:  stloc.1
+IL_0025:  ldarg.0
+IL_0026:  ldloc.1
+IL_0027:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>s__1'
+IL_002c:  leave.s    IL_002e
+}  // end handler
+IL_002e:  nop
+IL_002f:  ldc.i4.1
+IL_0030:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0035:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_003a:  stloc.3
+IL_003b:  ldloca.s   V_3
+IL_003d:  ldc.i4.0
+IL_003e:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0043:  stloc.s    V_4
+IL_0045:  ldloca.s   V_4
+IL_0047:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_004c:  stloc.2
+IL_004d:  ldloca.s   V_2
+IL_004f:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0054:  brtrue.s   IL_009a
+IL_0056:  ldarg.0
+IL_0057:  ldc.i4.0
+IL_0058:  dup
+IL_0059:  stloc.0
+IL_005a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_005f:  ldarg.0
+IL_0060:  ldloc.2
+IL_0061:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>u__1'
+IL_0066:  ldarg.0
+IL_0067:  stloc.s    V_5
+IL_0069:  ldarg.0
+IL_006a:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_006f:  ldloca.s   V_2
+IL_0071:  ldloca.s   V_5
+IL_0073:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'>(!!0&,
+!!1&)
+IL_0078:  nop
+IL_0079:  leave      IL_0106
+IL_007e:  ldarg.0
+IL_007f:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>u__1'
+IL_0084:  stloc.2
+IL_0085:  ldarg.0
+IL_0086:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>u__1'
+IL_008b:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0091:  ldarg.0
+IL_0092:  ldc.i4.m1
+IL_0093:  dup
+IL_0094:  stloc.0
+IL_0095:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_009a:  ldloca.s   V_2
+IL_009c:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_00a1:  nop
+IL_00a2:  nop
+IL_00a3:  ldarg.0
+IL_00a4:  ldfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>s__1'
+IL_00a9:  stloc.1
+IL_00aa:  ldloc.1
+IL_00ab:  brfalse.s  IL_00c8
+IL_00ad:  ldloc.1
+IL_00ae:  isinst     [System.Runtime]System.Exception
+IL_00b3:  stloc.s    V_6
+IL_00b5:  ldloc.s    V_6
+IL_00b7:  brtrue.s   IL_00bb
+IL_00b9:  ldloc.1
+IL_00ba:  throw
+IL_00bb:  ldloc.s    V_6
+IL_00bd:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00c2:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00c7:  nop
+IL_00c8:  ldarg.0
+IL_00c9:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>s__2'
+IL_00ce:  pop
+IL_00cf:  ldarg.0
+IL_00d0:  ldnull
+IL_00d1:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>s__1'
+IL_00d6:  leave.s    IL_00f2
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00d8:  stloc.s    V_6
+IL_00da:  ldarg.0
+IL_00db:  ldc.i4.s   -2
+IL_00dd:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_00e2:  ldarg.0
+IL_00e3:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_00e8:  ldloc.s    V_6
+IL_00ea:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00ef:  nop
+IL_00f0:  leave.s    IL_0106
+}  // end handler
+IL_00f2:  ldarg.0
+IL_00f3:  ldc.i4.s   -2
+IL_00f5:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_00fa:  ldarg.0
+IL_00fb:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_0100:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_0105:  nop
+IL_0106:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 Catch1() cil managed
 {
@@ -1098,6 +2036,198 @@ IL_0028:  ldloca.s   V_0
 IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Finally3>d__5'>(!!0&)
 IL_002f:  ldloc.0
 IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3>d__5'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Catch1_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 43 61 74 63 68 31 5F 57 69 74   // ally+<Catch1_Wit
+68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 36 00   // hValueTask>d__6.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.CatchAndFinally AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Catch2_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 43 61 74 63 68 32 5F 57 69 74   // ally+<Catch2_Wit
+68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 37 00   // hValueTask>d__7.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.CatchAndFinally AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Catch3_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 43 61 74 63 68 33 5F 57 69 74   // ally+<Catch3_Wit
+68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 38 00   // hValueTask>d__8.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.CatchAndFinally AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Finally1_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 46 69 6E 61 6C 6C 79 31 5F 57   // ally+<Finally1_W
+69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F   // ithValueTask>d__
+39 00 00 )                                        // 9..
+.maxstack  2
+.locals init (class AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.CatchAndFinally AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Finally2_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 46 69 6E 61 6C 6C 79 32 5F 57   // ally+<Finally2_W
+69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F   // ithValueTask>d__
+31 30 00 00 )                                     // 10..
+.maxstack  2
+.locals init (class AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.CatchAndFinally AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Finally3_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 46 69 6E 61 6C 6C 79 33 5F 57   // ally+<Finally3_W
+69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F   // ithValueTask>d__
+31 31 00 00 )                                     // 11..
+.maxstack  2
+.locals init (class AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.CatchAndFinally AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
 IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_003a:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileCatchAndFinally_Release.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileCatchAndFinally_Release.approved.txt
@@ -735,6 +735,764 @@ IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.Compil
 IL_000c:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<Catch1_WithValueTask>d__6'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0058
+IL_000a:  ldc.i4.0
+IL_000b:  stloc.1
+.try
+{
+IL_000c:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_0011:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0012:  pop
+IL_0013:  ldc.i4.1
+IL_0014:  stloc.1
+IL_0015:  leave.s    IL_0017
+}  // end handler
+IL_0017:  ldloc.1
+IL_0018:  ldc.i4.1
+IL_0019:  bne.un.s   IL_007b
+IL_001b:  ldc.i4.1
+IL_001c:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0021:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0026:  stloc.3
+IL_0027:  ldloca.s   V_3
+IL_0029:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::GetAwaiter()
+IL_002e:  stloc.2
+IL_002f:  ldloca.s   V_2
+IL_0031:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::get_IsCompleted()
+IL_0036:  brtrue.s   IL_0074
+IL_0038:  ldarg.0
+IL_0039:  ldc.i4.0
+IL_003a:  dup
+IL_003b:  stloc.0
+IL_003c:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0041:  ldarg.0
+IL_0042:  ldloc.2
+IL_0043:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>u__1'
+IL_0048:  ldarg.0
+IL_0049:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_004e:  ldloca.s   V_2
+IL_0050:  ldarg.0
+IL_0051:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter,valuetype AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'>(!!0&,
+!!1&)
+IL_0056:  leave.s    IL_00a9
+IL_0058:  ldarg.0
+IL_0059:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>u__1'
+IL_005e:  stloc.2
+IL_005f:  ldarg.0
+IL_0060:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>u__1'
+IL_0065:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter
+IL_006b:  ldarg.0
+IL_006c:  ldc.i4.m1
+IL_006d:  dup
+IL_006e:  stloc.0
+IL_006f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0074:  ldloca.s   V_2
+IL_0076:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::GetResult()
+IL_007b:  leave.s    IL_0096
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_007d:  stloc.s    V_4
+IL_007f:  ldarg.0
+IL_0080:  ldc.i4.s   -2
+IL_0082:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0087:  ldarg.0
+IL_0088:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_008d:  ldloc.s    V_4
+IL_008f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0094:  leave.s    IL_00a9
+}  // end handler
+IL_0096:  ldarg.0
+IL_0097:  ldc.i4.s   -2
+IL_0099:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_009e:  ldarg.0
+IL_009f:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_00a4:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00a9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Catch2_WithValueTask>d__7'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0062
+IL_000a:  ldc.i4.0
+IL_000b:  stloc.1
+.try
+{
+IL_000c:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_0011:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0012:  pop
+IL_0013:  ldc.i4.1
+IL_0014:  stloc.1
+IL_0015:  leave.s    IL_0017
+}  // end handler
+IL_0017:  ldloc.1
+IL_0018:  ldc.i4.1
+IL_0019:  bne.un.s   IL_0085
+IL_001b:  ldc.i4.1
+IL_001c:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0021:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_0026:  stloc.s    V_4
+IL_0028:  ldloca.s   V_4
+IL_002a:  ldc.i4.0
+IL_002b:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0030:  stloc.3
+IL_0031:  ldloca.s   V_3
+IL_0033:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0038:  stloc.2
+IL_0039:  ldloca.s   V_2
+IL_003b:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0040:  brtrue.s   IL_007e
+IL_0042:  ldarg.0
+IL_0043:  ldc.i4.0
+IL_0044:  dup
+IL_0045:  stloc.0
+IL_0046:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_004b:  ldarg.0
+IL_004c:  ldloc.2
+IL_004d:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>u__1'
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0058:  ldloca.s   V_2
+IL_005a:  ldarg.0
+IL_005b:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'>(!!0&,
+!!1&)
+IL_0060:  leave.s    IL_00b3
+IL_0062:  ldarg.0
+IL_0063:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>u__1'
+IL_0068:  stloc.2
+IL_0069:  ldarg.0
+IL_006a:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>u__1'
+IL_006f:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0075:  ldarg.0
+IL_0076:  ldc.i4.m1
+IL_0077:  dup
+IL_0078:  stloc.0
+IL_0079:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_007e:  ldloca.s   V_2
+IL_0080:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0085:  leave.s    IL_00a0
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0087:  stloc.s    V_5
+IL_0089:  ldarg.0
+IL_008a:  ldc.i4.s   -2
+IL_008c:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_0091:  ldarg.0
+IL_0092:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0097:  ldloc.s    V_5
+IL_0099:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_009e:  leave.s    IL_00b3
+}  // end handler
+IL_00a0:  ldarg.0
+IL_00a1:  ldc.i4.s   -2
+IL_00a3:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_00a8:  ldarg.0
+IL_00a9:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_00ae:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00b3:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Catch3_WithValueTask>d__8'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0062
+IL_000a:  ldc.i4.0
+IL_000b:  stloc.1
+.try
+{
+IL_000c:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_0011:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0012:  pop
+IL_0013:  ldc.i4.1
+IL_0014:  stloc.1
+IL_0015:  leave.s    IL_0017
+}  // end handler
+IL_0017:  ldloc.1
+IL_0018:  ldc.i4.1
+IL_0019:  bne.un.s   IL_0085
+IL_001b:  ldc.i4.1
+IL_001c:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0021:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0026:  stloc.3
+IL_0027:  ldloca.s   V_3
+IL_0029:  ldc.i4.0
+IL_002a:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_002f:  stloc.s    V_4
+IL_0031:  ldloca.s   V_4
+IL_0033:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0038:  stloc.2
+IL_0039:  ldloca.s   V_2
+IL_003b:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0040:  brtrue.s   IL_007e
+IL_0042:  ldarg.0
+IL_0043:  ldc.i4.0
+IL_0044:  dup
+IL_0045:  stloc.0
+IL_0046:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_004b:  ldarg.0
+IL_004c:  ldloc.2
+IL_004d:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>u__1'
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_0058:  ldloca.s   V_2
+IL_005a:  ldarg.0
+IL_005b:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'>(!!0&,
+!!1&)
+IL_0060:  leave.s    IL_00b3
+IL_0062:  ldarg.0
+IL_0063:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>u__1'
+IL_0068:  stloc.2
+IL_0069:  ldarg.0
+IL_006a:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>u__1'
+IL_006f:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0075:  ldarg.0
+IL_0076:  ldc.i4.m1
+IL_0077:  dup
+IL_0078:  stloc.0
+IL_0079:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_007e:  ldloca.s   V_2
+IL_0080:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0085:  leave.s    IL_00a0
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0087:  stloc.s    V_5
+IL_0089:  ldarg.0
+IL_008a:  ldc.i4.s   -2
+IL_008c:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_0091:  ldarg.0
+IL_0092:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_0097:  ldloc.s    V_5
+IL_0099:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_009e:  leave.s    IL_00b3
+}  // end handler
+IL_00a0:  ldarg.0
+IL_00a1:  ldc.i4.s   -2
+IL_00a3:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_00a8:  ldarg.0
+IL_00a9:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_00ae:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00b3:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Finally1_WithValueTask>d__9'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private object '<>7__wrap1'
+.field private int32 '<>7__wrap2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0065
+IL_000a:  ldarg.0
+IL_000b:  ldnull
+IL_000c:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>7__wrap1'
+IL_0011:  ldarg.0
+IL_0012:  ldc.i4.0
+IL_0013:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>7__wrap2'
+.try
+{
+IL_0018:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_001d:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_001e:  stloc.1
+IL_001f:  ldarg.0
+IL_0020:  ldloc.1
+IL_0021:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>7__wrap1'
+IL_0026:  leave.s    IL_0028
+}  // end handler
+IL_0028:  ldc.i4.1
+IL_0029:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_002e:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0033:  stloc.3
+IL_0034:  ldloca.s   V_3
+IL_0036:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::GetAwaiter()
+IL_003b:  stloc.2
+IL_003c:  ldloca.s   V_2
+IL_003e:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::get_IsCompleted()
+IL_0043:  brtrue.s   IL_0081
+IL_0045:  ldarg.0
+IL_0046:  ldc.i4.0
+IL_0047:  dup
+IL_0048:  stloc.0
+IL_0049:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_004e:  ldarg.0
+IL_004f:  ldloc.2
+IL_0050:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>u__1'
+IL_0055:  ldarg.0
+IL_0056:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_005b:  ldloca.s   V_2
+IL_005d:  ldarg.0
+IL_005e:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter,valuetype AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'>(!!0&,
+!!1&)
+IL_0063:  leave.s    IL_00dc
+IL_0065:  ldarg.0
+IL_0066:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>u__1'
+IL_006b:  stloc.2
+IL_006c:  ldarg.0
+IL_006d:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>u__1'
+IL_0072:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter
+IL_0078:  ldarg.0
+IL_0079:  ldc.i4.m1
+IL_007a:  dup
+IL_007b:  stloc.0
+IL_007c:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_0081:  ldloca.s   V_2
+IL_0083:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::GetResult()
+IL_0088:  ldarg.0
+IL_0089:  ldfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>7__wrap1'
+IL_008e:  stloc.1
+IL_008f:  ldloc.1
+IL_0090:  brfalse.s  IL_00a7
+IL_0092:  ldloc.1
+IL_0093:  isinst     [System.Runtime]System.Exception
+IL_0098:  dup
+IL_0099:  brtrue.s   IL_009d
+IL_009b:  ldloc.1
+IL_009c:  throw
+IL_009d:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00a2:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00a7:  ldarg.0
+IL_00a8:  ldnull
+IL_00a9:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>7__wrap1'
+IL_00ae:  leave.s    IL_00c9
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00b0:  stloc.s    V_4
+IL_00b2:  ldarg.0
+IL_00b3:  ldc.i4.s   -2
+IL_00b5:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_00ba:  ldarg.0
+IL_00bb:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_00c0:  ldloc.s    V_4
+IL_00c2:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00c7:  leave.s    IL_00dc
+}  // end handler
+IL_00c9:  ldarg.0
+IL_00ca:  ldc.i4.s   -2
+IL_00cc:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_00d1:  ldarg.0
+IL_00d2:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_00d7:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00dc:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Finally2_WithValueTask>d__10'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private object '<>7__wrap1'
+.field private int32 '<>7__wrap2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0072
+IL_000a:  ldarg.0
+IL_000b:  ldnull
+IL_000c:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>7__wrap1'
+IL_0011:  ldarg.0
+IL_0012:  ldc.i4.0
+IL_0013:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>7__wrap2'
+.try
+{
+IL_0018:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_001d:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_001e:  stloc.1
+IL_001f:  ldarg.0
+IL_0020:  ldloc.1
+IL_0021:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>7__wrap1'
+IL_0026:  leave.s    IL_0028
+}  // end handler
+IL_0028:  ldc.i4.1
+IL_0029:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_002e:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_0033:  stloc.s    V_4
+IL_0035:  ldloca.s   V_4
+IL_0037:  ldc.i4.0
+IL_0038:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_003d:  stloc.3
+IL_003e:  ldloca.s   V_3
+IL_0040:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0045:  stloc.2
+IL_0046:  ldloca.s   V_2
+IL_0048:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_004d:  brtrue.s   IL_008e
+IL_004f:  ldarg.0
+IL_0050:  ldc.i4.0
+IL_0051:  dup
+IL_0052:  stloc.0
+IL_0053:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_0058:  ldarg.0
+IL_0059:  ldloc.2
+IL_005a:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>u__1'
+IL_005f:  ldarg.0
+IL_0060:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_0065:  ldloca.s   V_2
+IL_0067:  ldarg.0
+IL_0068:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'>(!!0&,
+!!1&)
+IL_006d:  leave      IL_00e9
+IL_0072:  ldarg.0
+IL_0073:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>u__1'
+IL_0078:  stloc.2
+IL_0079:  ldarg.0
+IL_007a:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>u__1'
+IL_007f:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0085:  ldarg.0
+IL_0086:  ldc.i4.m1
+IL_0087:  dup
+IL_0088:  stloc.0
+IL_0089:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_008e:  ldloca.s   V_2
+IL_0090:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0095:  ldarg.0
+IL_0096:  ldfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>7__wrap1'
+IL_009b:  stloc.1
+IL_009c:  ldloc.1
+IL_009d:  brfalse.s  IL_00b4
+IL_009f:  ldloc.1
+IL_00a0:  isinst     [System.Runtime]System.Exception
+IL_00a5:  dup
+IL_00a6:  brtrue.s   IL_00aa
+IL_00a8:  ldloc.1
+IL_00a9:  throw
+IL_00aa:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00af:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00b4:  ldarg.0
+IL_00b5:  ldnull
+IL_00b6:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>7__wrap1'
+IL_00bb:  leave.s    IL_00d6
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00bd:  stloc.s    V_5
+IL_00bf:  ldarg.0
+IL_00c0:  ldc.i4.s   -2
+IL_00c2:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_00c7:  ldarg.0
+IL_00c8:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_00cd:  ldloc.s    V_5
+IL_00cf:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00d4:  leave.s    IL_00e9
+}  // end handler
+IL_00d6:  ldarg.0
+IL_00d7:  ldc.i4.s   -2
+IL_00d9:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_00de:  ldarg.0
+IL_00df:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_00e4:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00e9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Finally3_WithValueTask>d__11'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private object '<>7__wrap1'
+.field private int32 '<>7__wrap2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_006f
+IL_000a:  ldarg.0
+IL_000b:  ldnull
+IL_000c:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>7__wrap1'
+IL_0011:  ldarg.0
+IL_0012:  ldc.i4.0
+IL_0013:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>7__wrap2'
+.try
+{
+IL_0018:  newobj     instance void [System.Runtime]System.NotImplementedException::.ctor()
+IL_001d:  throw
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_001e:  stloc.1
+IL_001f:  ldarg.0
+IL_0020:  ldloc.1
+IL_0021:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>7__wrap1'
+IL_0026:  leave.s    IL_0028
+}  // end handler
+IL_0028:  ldc.i4.1
+IL_0029:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_002e:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0033:  stloc.3
+IL_0034:  ldloca.s   V_3
+IL_0036:  ldc.i4.0
+IL_0037:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_003c:  stloc.s    V_4
+IL_003e:  ldloca.s   V_4
+IL_0040:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0045:  stloc.2
+IL_0046:  ldloca.s   V_2
+IL_0048:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_004d:  brtrue.s   IL_008b
+IL_004f:  ldarg.0
+IL_0050:  ldc.i4.0
+IL_0051:  dup
+IL_0052:  stloc.0
+IL_0053:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_0058:  ldarg.0
+IL_0059:  ldloc.2
+IL_005a:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>u__1'
+IL_005f:  ldarg.0
+IL_0060:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_0065:  ldloca.s   V_2
+IL_0067:  ldarg.0
+IL_0068:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'>(!!0&,
+!!1&)
+IL_006d:  leave.s    IL_00e6
+IL_006f:  ldarg.0
+IL_0070:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>u__1'
+IL_0075:  stloc.2
+IL_0076:  ldarg.0
+IL_0077:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>u__1'
+IL_007c:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0082:  ldarg.0
+IL_0083:  ldc.i4.m1
+IL_0084:  dup
+IL_0085:  stloc.0
+IL_0086:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_008b:  ldloca.s   V_2
+IL_008d:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0092:  ldarg.0
+IL_0093:  ldfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>7__wrap1'
+IL_0098:  stloc.1
+IL_0099:  ldloc.1
+IL_009a:  brfalse.s  IL_00b1
+IL_009c:  ldloc.1
+IL_009d:  isinst     [System.Runtime]System.Exception
+IL_00a2:  dup
+IL_00a3:  brtrue.s   IL_00a7
+IL_00a5:  ldloc.1
+IL_00a6:  throw
+IL_00a7:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00ac:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00b1:  ldarg.0
+IL_00b2:  ldnull
+IL_00b3:  stfld      object AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>7__wrap1'
+IL_00b8:  leave.s    IL_00d3
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00ba:  stloc.s    V_5
+IL_00bc:  ldarg.0
+IL_00bd:  ldc.i4.s   -2
+IL_00bf:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_00c4:  ldarg.0
+IL_00c5:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_00ca:  ldloc.s    V_5
+IL_00cc:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00d1:  leave.s    IL_00e6
+}  // end handler
+IL_00d3:  ldarg.0
+IL_00d4:  ldc.i4.s   -2
+IL_00d6:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_00db:  ldarg.0
+IL_00dc:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_00e1:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00e6:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 Catch1() cil managed
 {
@@ -888,6 +1646,168 @@ IL_001d:  ldloca.s   V_0
 IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Finally3>d__5'>(!!0&)
 IL_0024:  ldloca.s   V_0
 IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3>d__5'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Catch1_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 43 61 74 63 68 31 5F 57 69 74   // ally+<Catch1_Wit
+68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 36 00   // hValueTask>d__6.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch1_WithValueTask>d__6'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Catch2_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 43 61 74 63 68 32 5F 57 69 74   // ally+<Catch2_Wit
+68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 37 00   // hValueTask>d__7.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch2_WithValueTask>d__7'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Catch3_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 43 61 74 63 68 33 5F 57 69 74   // ally+<Catch3_Wit
+68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 38 00   // hValueTask>d__8.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Catch3_WithValueTask>d__8'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Finally1_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 46 69 6E 61 6C 6C 79 31 5F 57   // ally+<Finally1_W
+69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F   // ithValueTask>d__
+39 00 00 )                                        // 9..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally1_WithValueTask>d__9'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Finally2_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 46 69 6E 61 6C 6C 79 32 5F 57   // ally+<Finally2_W
+69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F   // ithValueTask>d__
+31 30 00 00 )                                     // 10..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally2_WithValueTask>d__10'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Finally3_WithValueTask() cil managed
+{
+63 65 73 73 2E 43 61 74 63 68 41 6E 64 46 69 6E   // cess.CatchAndFin
+61 6C 6C 79 2B 3C 46 69 6E 61 6C 6C 79 33 5F 57   // ally+<Finally3_W
+69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F   // ithValueTask>d__
+31 31 00 00 )                                     // 11..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.CatchAndFinally/'<Finally3_WithValueTask>d__11'::'<>t__builder'
 IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0030:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileExample_Debug.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileExample_Debug.approved.txt
@@ -1851,6 +1851,1919 @@ instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.Comp
 IL_0000:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod1_WithValueTask>d__12'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_2,
+class AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_0050
+IL_000e:  nop
+IL_000f:  ldc.i4.1
+IL_0010:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0015:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_001a:  stloc.2
+IL_001b:  ldloca.s   V_2
+IL_001d:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::GetAwaiter()
+IL_0022:  stloc.1
+IL_0023:  ldloca.s   V_1
+IL_0025:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::get_IsCompleted()
+IL_002a:  brtrue.s   IL_006c
+IL_002c:  ldarg.0
+IL_002d:  ldc.i4.0
+IL_002e:  dup
+IL_002f:  stloc.0
+IL_0030:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0035:  ldarg.0
+IL_0036:  ldloc.1
+IL_0037:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>u__1'
+IL_003c:  ldarg.0
+IL_003d:  stloc.3
+IL_003e:  ldarg.0
+IL_003f:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0044:  ldloca.s   V_1
+IL_0046:  ldloca.s   V_3
+IL_0048:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter,class AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'>(!!0&,
+!!1&)
+IL_004d:  nop
+IL_004e:  leave.s    IL_00a4
+IL_0050:  ldarg.0
+IL_0051:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>u__1'
+IL_0056:  stloc.1
+IL_0057:  ldarg.0
+IL_0058:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>u__1'
+IL_005d:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter
+IL_0063:  ldarg.0
+IL_0064:  ldc.i4.m1
+IL_0065:  dup
+IL_0066:  stloc.0
+IL_0067:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_006c:  ldloca.s   V_1
+IL_006e:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::GetResult()
+IL_0073:  nop
+IL_0074:  leave.s    IL_0090
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0076:  stloc.s    V_4
+IL_0078:  ldarg.0
+IL_0079:  ldc.i4.s   -2
+IL_007b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0080:  ldarg.0
+IL_0081:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0086:  ldloc.s    V_4
+IL_0088:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_008d:  nop
+IL_008e:  leave.s    IL_00a4
+}  // end handler
+IL_0090:  ldarg.0
+IL_0091:  ldc.i4.s   -2
+IL_0093:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0098:  ldarg.0
+IL_0099:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_009e:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00a3:  nop
+IL_00a4:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod2_WithValueTask>d__13'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+class AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13' V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005a
+IL_000e:  nop
+IL_000f:  ldc.i4.1
+IL_0010:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0015:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_001a:  stloc.3
+IL_001b:  ldloca.s   V_3
+IL_001d:  ldc.i4.0
+IL_001e:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0023:  stloc.2
+IL_0024:  ldloca.s   V_2
+IL_0026:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_002b:  stloc.1
+IL_002c:  ldloca.s   V_1
+IL_002e:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0033:  brtrue.s   IL_0076
+IL_0035:  ldarg.0
+IL_0036:  ldc.i4.0
+IL_0037:  dup
+IL_0038:  stloc.0
+IL_0039:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_003e:  ldarg.0
+IL_003f:  ldloc.1
+IL_0040:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>u__1'
+IL_0045:  ldarg.0
+IL_0046:  stloc.s    V_4
+IL_0048:  ldarg.0
+IL_0049:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_004e:  ldloca.s   V_1
+IL_0050:  ldloca.s   V_4
+IL_0052:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'>(!!0&,
+!!1&)
+IL_0057:  nop
+IL_0058:  leave.s    IL_00ae
+IL_005a:  ldarg.0
+IL_005b:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>u__1'
+IL_0060:  stloc.1
+IL_0061:  ldarg.0
+IL_0062:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>u__1'
+IL_0067:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_006d:  ldarg.0
+IL_006e:  ldc.i4.m1
+IL_006f:  dup
+IL_0070:  stloc.0
+IL_0071:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_0076:  ldloca.s   V_1
+IL_0078:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_007d:  nop
+IL_007e:  leave.s    IL_009a
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0080:  stloc.s    V_5
+IL_0082:  ldarg.0
+IL_0083:  ldc.i4.s   -2
+IL_0085:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_008a:  ldarg.0
+IL_008b:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0090:  ldloc.s    V_5
+IL_0092:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0097:  nop
+IL_0098:  leave.s    IL_00ae
+}  // end handler
+IL_009a:  ldarg.0
+IL_009b:  ldc.i4.s   -2
+IL_009d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_00a2:  ldarg.0
+IL_00a3:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_00a8:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00ad:  nop
+IL_00ae:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod3_WithValueTask>d__14'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+class AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14' V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005a
+IL_000e:  nop
+IL_000f:  ldc.i4.1
+IL_0010:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0015:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_001a:  stloc.2
+IL_001b:  ldloca.s   V_2
+IL_001d:  ldc.i4.0
+IL_001e:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0023:  stloc.3
+IL_0024:  ldloca.s   V_3
+IL_0026:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_002b:  stloc.1
+IL_002c:  ldloca.s   V_1
+IL_002e:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0033:  brtrue.s   IL_0076
+IL_0035:  ldarg.0
+IL_0036:  ldc.i4.0
+IL_0037:  dup
+IL_0038:  stloc.0
+IL_0039:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_003e:  ldarg.0
+IL_003f:  ldloc.1
+IL_0040:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>u__1'
+IL_0045:  ldarg.0
+IL_0046:  stloc.s    V_4
+IL_0048:  ldarg.0
+IL_0049:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_004e:  ldloca.s   V_1
+IL_0050:  ldloca.s   V_4
+IL_0052:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'>(!!0&,
+!!1&)
+IL_0057:  nop
+IL_0058:  leave.s    IL_00ae
+IL_005a:  ldarg.0
+IL_005b:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>u__1'
+IL_0060:  stloc.1
+IL_0061:  ldarg.0
+IL_0062:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>u__1'
+IL_0067:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_006d:  ldarg.0
+IL_006e:  ldc.i4.m1
+IL_006f:  dup
+IL_0070:  stloc.0
+IL_0071:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_0076:  ldloca.s   V_1
+IL_0078:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_007d:  nop
+IL_007e:  leave.s    IL_009a
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0080:  stloc.s    V_5
+IL_0082:  ldarg.0
+IL_0083:  ldc.i4.s   -2
+IL_0085:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_008a:  ldarg.0
+IL_008b:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0090:  ldloc.s    V_5
+IL_0092:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0097:  nop
+IL_0098:  leave.s    IL_00ae
+}  // end handler
+IL_009a:  ldarg.0
+IL_009b:  ldc.i4.s   -2
+IL_009d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_00a2:  ldarg.0
+IL_00a3:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_00a8:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00ad:  nop
+IL_00ae:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod4_WithValueTask>d__15'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private int32 '<result>5__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_3,
+class AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15' V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_0052
+IL_000e:  nop
+IL_000f:  ldc.i4.s   10
+IL_0011:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0016:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_001b:  stloc.3
+IL_001c:  ldloca.s   V_3
+IL_001e:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::GetAwaiter()
+IL_0023:  stloc.2
+IL_0024:  ldloca.s   V_2
+IL_0026:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::get_IsCompleted()
+IL_002b:  brtrue.s   IL_006e
+IL_002d:  ldarg.0
+IL_002e:  ldc.i4.0
+IL_002f:  dup
+IL_0030:  stloc.0
+IL_0031:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0036:  ldarg.0
+IL_0037:  ldloc.2
+IL_0038:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>u__1'
+IL_003d:  ldarg.0
+IL_003e:  stloc.s    V_4
+IL_0040:  ldarg.0
+IL_0041:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_0046:  ldloca.s   V_2
+IL_0048:  ldloca.s   V_4
+IL_004a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>,class AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'>(!!0&,
+!!1&)
+IL_004f:  nop
+IL_0050:  leave.s    IL_00bf
+IL_0052:  ldarg.0
+IL_0053:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>u__1'
+IL_0058:  stloc.2
+IL_0059:  ldarg.0
+IL_005a:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>u__1'
+IL_005f:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>
+IL_0065:  ldarg.0
+IL_0066:  ldc.i4.m1
+IL_0067:  dup
+IL_0068:  stloc.0
+IL_0069:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_006e:  ldarg.0
+IL_006f:  ldloca.s   V_2
+IL_0071:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::GetResult()
+IL_0076:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>s__2'
+IL_007b:  ldarg.0
+IL_007c:  ldarg.0
+IL_007d:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>s__2'
+IL_0082:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<result>5__1'
+IL_0087:  ldarg.0
+IL_0088:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<result>5__1'
+IL_008d:  stloc.1
+IL_008e:  leave.s    IL_00aa
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0090:  stloc.s    V_5
+IL_0092:  ldarg.0
+IL_0093:  ldc.i4.s   -2
+IL_0095:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_009a:  ldarg.0
+IL_009b:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_00a0:  ldloc.s    V_5
+IL_00a2:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_00a7:  nop
+IL_00a8:  leave.s    IL_00bf
+}  // end handler
+IL_00aa:  ldarg.0
+IL_00ab:  ldc.i4.s   -2
+IL_00ad:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_00b2:  ldarg.0
+IL_00b3:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_00b8:  ldloc.1
+IL_00b9:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_00be:  nop
+IL_00bf:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod5_WithValueTask>d__16'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private int32 '<result>5__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_4,
+class AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005c
+IL_000e:  nop
+IL_000f:  ldc.i4.s   10
+IL_0011:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0016:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_001b:  stloc.s    V_4
+IL_001d:  ldloca.s   V_4
+IL_001f:  ldc.i4.0
+IL_0020:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_0025:  stloc.3
+IL_0026:  ldloca.s   V_3
+IL_0028:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_002d:  stloc.2
+IL_002e:  ldloca.s   V_2
+IL_0030:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0035:  brtrue.s   IL_0078
+IL_0037:  ldarg.0
+IL_0038:  ldc.i4.0
+IL_0039:  dup
+IL_003a:  stloc.0
+IL_003b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0040:  ldarg.0
+IL_0041:  ldloc.2
+IL_0042:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>u__1'
+IL_0047:  ldarg.0
+IL_0048:  stloc.s    V_5
+IL_004a:  ldarg.0
+IL_004b:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0050:  ldloca.s   V_2
+IL_0052:  ldloca.s   V_5
+IL_0054:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,class AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'>(!!0&,
+!!1&)
+IL_0059:  nop
+IL_005a:  leave.s    IL_00c9
+IL_005c:  ldarg.0
+IL_005d:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>u__1'
+IL_0062:  stloc.2
+IL_0063:  ldarg.0
+IL_0064:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>u__1'
+IL_0069:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_006f:  ldarg.0
+IL_0070:  ldc.i4.m1
+IL_0071:  dup
+IL_0072:  stloc.0
+IL_0073:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0078:  ldarg.0
+IL_0079:  ldloca.s   V_2
+IL_007b:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0080:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>s__2'
+IL_0085:  ldarg.0
+IL_0086:  ldarg.0
+IL_0087:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>s__2'
+IL_008c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<result>5__1'
+IL_0091:  ldarg.0
+IL_0092:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<result>5__1'
+IL_0097:  stloc.1
+IL_0098:  leave.s    IL_00b4
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_009a:  stloc.s    V_6
+IL_009c:  ldarg.0
+IL_009d:  ldc.i4.s   -2
+IL_009f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_00a4:  ldarg.0
+IL_00a5:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_00aa:  ldloc.s    V_6
+IL_00ac:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_00b1:  nop
+IL_00b2:  leave.s    IL_00c9
+}  // end handler
+IL_00b4:  ldarg.0
+IL_00b5:  ldc.i4.s   -2
+IL_00b7:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_00bc:  ldarg.0
+IL_00bd:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_00c2:  ldloc.1
+IL_00c3:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_00c8:  nop
+IL_00c9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod6_WithValueTask>d__17'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private int32 '<result>5__1'
+.field private int32 '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_4,
+class AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005c
+IL_000e:  nop
+IL_000f:  ldc.i4.s   10
+IL_0011:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0016:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_001b:  stloc.3
+IL_001c:  ldloca.s   V_3
+IL_001e:  ldc.i4.0
+IL_001f:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_0024:  stloc.s    V_4
+IL_0026:  ldloca.s   V_4
+IL_0028:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_002d:  stloc.2
+IL_002e:  ldloca.s   V_2
+IL_0030:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0035:  brtrue.s   IL_0078
+IL_0037:  ldarg.0
+IL_0038:  ldc.i4.0
+IL_0039:  dup
+IL_003a:  stloc.0
+IL_003b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0040:  ldarg.0
+IL_0041:  ldloc.2
+IL_0042:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>u__1'
+IL_0047:  ldarg.0
+IL_0048:  stloc.s    V_5
+IL_004a:  ldarg.0
+IL_004b:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0050:  ldloca.s   V_2
+IL_0052:  ldloca.s   V_5
+IL_0054:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,class AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'>(!!0&,
+!!1&)
+IL_0059:  nop
+IL_005a:  leave.s    IL_00c9
+IL_005c:  ldarg.0
+IL_005d:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>u__1'
+IL_0062:  stloc.2
+IL_0063:  ldarg.0
+IL_0064:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>u__1'
+IL_0069:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_006f:  ldarg.0
+IL_0070:  ldc.i4.m1
+IL_0071:  dup
+IL_0072:  stloc.0
+IL_0073:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0078:  ldarg.0
+IL_0079:  ldloca.s   V_2
+IL_007b:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0080:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>s__2'
+IL_0085:  ldarg.0
+IL_0086:  ldarg.0
+IL_0087:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>s__2'
+IL_008c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<result>5__1'
+IL_0091:  ldarg.0
+IL_0092:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<result>5__1'
+IL_0097:  stloc.1
+IL_0098:  leave.s    IL_00b4
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_009a:  stloc.s    V_6
+IL_009c:  ldarg.0
+IL_009d:  ldc.i4.s   -2
+IL_009f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_00a4:  ldarg.0
+IL_00a5:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_00aa:  ldloc.s    V_6
+IL_00ac:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_00b1:  nop
+IL_00b2:  leave.s    IL_00c9
+}  // end handler
+IL_00b4:  ldarg.0
+IL_00b5:  ldc.i4.s   -2
+IL_00b7:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_00bc:  ldarg.0
+IL_00bd:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_00c2:  ldloc.1
+IL_00c3:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_00c8:  nop
+IL_00c9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod7_WithValueTask>d__18'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private int32 '<count>5__1'
+.field private int32 '<sum>5__2'
+.field private int32 '<>s__3'
+.field private int32 '<i>5__4'
+.field private int32 '<>s__5'
+.field private int32 '<>s__6'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> '<>u__1'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter '<>u__2'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> '<>u__3'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_3,
+class AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18' V_4,
+valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter V_5,
+valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> V_6,
+int32 V_7,
+bool V_8,
+class [System.Runtime]System.Exception V_9)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  switch     (
+IL_001b,
+IL_001d,
+IL_0022)
+IL_0019:  br.s       IL_0027
+IL_001b:  br.s       IL_006e
+IL_001d:  br         IL_00f6
+IL_0022:  br         IL_016b
+IL_0027:  nop
+IL_0028:  ldc.i4.s   10
+IL_002a:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_002f:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0034:  stloc.3
+IL_0035:  ldloca.s   V_3
+IL_0037:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::GetAwaiter()
+IL_003c:  stloc.2
+IL_003d:  ldloca.s   V_2
+IL_003f:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::get_IsCompleted()
+IL_0044:  brtrue.s   IL_008a
+IL_0046:  ldarg.0
+IL_0047:  ldc.i4.0
+IL_0048:  dup
+IL_0049:  stloc.0
+IL_004a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_004f:  ldarg.0
+IL_0050:  ldloc.2
+IL_0051:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__1'
+IL_0056:  ldarg.0
+IL_0057:  stloc.s    V_4
+IL_0059:  ldarg.0
+IL_005a:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_005f:  ldloca.s   V_2
+IL_0061:  ldloca.s   V_4
+IL_0063:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>,class AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&,
+!!1&)
+IL_0068:  nop
+IL_0069:  leave      IL_020a
+IL_006e:  ldarg.0
+IL_006f:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__1'
+IL_0074:  stloc.2
+IL_0075:  ldarg.0
+IL_0076:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__1'
+IL_007b:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>
+IL_0081:  ldarg.0
+IL_0082:  ldc.i4.m1
+IL_0083:  dup
+IL_0084:  stloc.0
+IL_0085:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_008a:  ldarg.0
+IL_008b:  ldloca.s   V_2
+IL_008d:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::GetResult()
+IL_0092:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>s__3'
+IL_0097:  ldarg.0
+IL_0098:  ldarg.0
+IL_0099:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>s__3'
+IL_009e:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<count>5__1'
+IL_00a3:  ldarg.0
+IL_00a4:  ldc.i4.0
+IL_00a5:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__2'
+IL_00aa:  ldarg.0
+IL_00ab:  ldc.i4.0
+IL_00ac:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_00b1:  br         IL_01bb
+IL_00b6:  nop
+IL_00b7:  ldc.i4.1
+IL_00b8:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00bd:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter [System.Runtime]System.Threading.Tasks.Task::GetAwaiter()
+IL_00c2:  stloc.s    V_5
+IL_00c4:  ldloca.s   V_5
+IL_00c6:  call       instance bool [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter::get_IsCompleted()
+IL_00cb:  brtrue.s   IL_0113
+IL_00cd:  ldarg.0
+IL_00ce:  ldc.i4.1
+IL_00cf:  dup
+IL_00d0:  stloc.0
+IL_00d1:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_00d6:  ldarg.0
+IL_00d7:  ldloc.s    V_5
+IL_00d9:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__2'
+IL_00de:  ldarg.0
+IL_00df:  stloc.s    V_4
+IL_00e1:  ldarg.0
+IL_00e2:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_00e7:  ldloca.s   V_5
+IL_00e9:  ldloca.s   V_4
+IL_00eb:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter,class AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&,
+!!1&)
+IL_00f0:  nop
+IL_00f1:  leave      IL_020a
+IL_00f6:  ldarg.0
+IL_00f7:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__2'
+IL_00fc:  stloc.s    V_5
+IL_00fe:  ldarg.0
+IL_00ff:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__2'
+IL_0104:  initobj    [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter
+IL_010a:  ldarg.0
+IL_010b:  ldc.i4.m1
+IL_010c:  dup
+IL_010d:  stloc.0
+IL_010e:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0113:  ldloca.s   V_5
+IL_0115:  call       instance void [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter::GetResult()
+IL_011a:  nop
+IL_011b:  ldarg.0
+IL_011c:  ldarg.0
+IL_011d:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__2'
+IL_0122:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>s__5'
+IL_0127:  ldarg.0
+IL_0128:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_012d:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0132:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<!0> class [System.Runtime]System.Threading.Tasks.Task`1<int32>::GetAwaiter()
+IL_0137:  stloc.s    V_6
+IL_0139:  ldloca.s   V_6
+IL_013b:  call       instance bool valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>::get_IsCompleted()
+IL_0140:  brtrue.s   IL_0188
+IL_0142:  ldarg.0
+IL_0143:  ldc.i4.2
+IL_0144:  dup
+IL_0145:  stloc.0
+IL_0146:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_014b:  ldarg.0
+IL_014c:  ldloc.s    V_6
+IL_014e:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__3'
+IL_0153:  ldarg.0
+IL_0154:  stloc.s    V_4
+IL_0156:  ldarg.0
+IL_0157:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_015c:  ldloca.s   V_6
+IL_015e:  ldloca.s   V_4
+IL_0160:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>,class AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&,
+!!1&)
+IL_0165:  nop
+IL_0166:  leave      IL_020a
+IL_016b:  ldarg.0
+IL_016c:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__3'
+IL_0171:  stloc.s    V_6
+IL_0173:  ldarg.0
+IL_0174:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__3'
+IL_0179:  initobj    valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>
+IL_017f:  ldarg.0
+IL_0180:  ldc.i4.m1
+IL_0181:  dup
+IL_0182:  stloc.0
+IL_0183:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0188:  ldarg.0
+IL_0189:  ldloca.s   V_6
+IL_018b:  call       instance !0 valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>::GetResult()
+IL_0190:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>s__6'
+IL_0195:  ldarg.0
+IL_0196:  ldarg.0
+IL_0197:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>s__5'
+IL_019c:  ldarg.0
+IL_019d:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>s__6'
+IL_01a2:  add
+IL_01a3:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__2'
+IL_01a8:  nop
+IL_01a9:  ldarg.0
+IL_01aa:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_01af:  stloc.s    V_7
+IL_01b1:  ldarg.0
+IL_01b2:  ldloc.s    V_7
+IL_01b4:  ldc.i4.1
+IL_01b5:  add
+IL_01b6:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_01bb:  ldarg.0
+IL_01bc:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_01c1:  ldarg.0
+IL_01c2:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<count>5__1'
+IL_01c7:  clt
+IL_01c9:  stloc.s    V_8
+IL_01cb:  ldloc.s    V_8
+IL_01cd:  brtrue     IL_00b6
+IL_01d2:  ldarg.0
+IL_01d3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__2'
+IL_01d8:  stloc.1
+IL_01d9:  leave.s    IL_01f5
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_01db:  stloc.s    V_9
+IL_01dd:  ldarg.0
+IL_01de:  ldc.i4.s   -2
+IL_01e0:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_01e5:  ldarg.0
+IL_01e6:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_01eb:  ldloc.s    V_9
+IL_01ed:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_01f2:  nop
+IL_01f3:  leave.s    IL_020a
+}  // end handler
+IL_01f5:  ldarg.0
+IL_01f6:  ldc.i4.s   -2
+IL_01f8:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_01fd:  ldarg.0
+IL_01fe:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_0203:  ldloc.1
+IL_0204:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_0209:  nop
+IL_020a:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod8_WithValueTask>d__19'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private int32 '<count>5__1'
+.field private int32 '<sum>5__2'
+.field private int32 '<>s__3'
+.field private int32 '<i>5__4'
+.field private int32 '<>s__5'
+.field private int32 '<>s__6'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__2'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_4,
+class AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19' V_5,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_6,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_7,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_8,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_9,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_10,
+int32 V_11,
+bool V_12,
+class [System.Runtime]System.Exception V_13)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  switch     (
+IL_001b,
+IL_001d,
+IL_0022)
+IL_0019:  br.s       IL_0027
+IL_001b:  br.s       IL_0078
+IL_001d:  br         IL_0113
+IL_0022:  br         IL_019b
+IL_0027:  nop
+IL_0028:  ldc.i4.s   10
+IL_002a:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_002f:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0034:  stloc.s    V_4
+IL_0036:  ldloca.s   V_4
+IL_0038:  ldc.i4.0
+IL_0039:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_003e:  stloc.3
+IL_003f:  ldloca.s   V_3
+IL_0041:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0046:  stloc.2
+IL_0047:  ldloca.s   V_2
+IL_0049:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_004e:  brtrue.s   IL_0094
+IL_0050:  ldarg.0
+IL_0051:  ldc.i4.0
+IL_0052:  dup
+IL_0053:  stloc.0
+IL_0054:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0059:  ldarg.0
+IL_005a:  ldloc.2
+IL_005b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_0060:  ldarg.0
+IL_0061:  stloc.s    V_5
+IL_0063:  ldarg.0
+IL_0064:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0069:  ldloca.s   V_2
+IL_006b:  ldloca.s   V_5
+IL_006d:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,class AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&,
+!!1&)
+IL_0072:  nop
+IL_0073:  leave      IL_023a
+IL_0078:  ldarg.0
+IL_0079:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_007e:  stloc.2
+IL_007f:  ldarg.0
+IL_0080:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_0085:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_008b:  ldarg.0
+IL_008c:  ldc.i4.m1
+IL_008d:  dup
+IL_008e:  stloc.0
+IL_008f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0094:  ldarg.0
+IL_0095:  ldloca.s   V_2
+IL_0097:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_009c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>s__3'
+IL_00a1:  ldarg.0
+IL_00a2:  ldarg.0
+IL_00a3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>s__3'
+IL_00a8:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<count>5__1'
+IL_00ad:  ldarg.0
+IL_00ae:  ldc.i4.0
+IL_00af:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__2'
+IL_00b4:  ldarg.0
+IL_00b5:  ldc.i4.0
+IL_00b6:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_00bb:  br         IL_01eb
+IL_00c0:  nop
+IL_00c1:  ldc.i4.1
+IL_00c2:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00c7:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_00cc:  stloc.s    V_9
+IL_00ce:  ldloca.s   V_9
+IL_00d0:  ldc.i4.0
+IL_00d1:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_00d6:  stloc.s    V_6
+IL_00d8:  ldloca.s   V_6
+IL_00da:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_00df:  stloc.s    V_7
+IL_00e1:  ldloca.s   V_7
+IL_00e3:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_00e8:  brtrue.s   IL_0130
+IL_00ea:  ldarg.0
+IL_00eb:  ldc.i4.1
+IL_00ec:  dup
+IL_00ed:  stloc.0
+IL_00ee:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_00f3:  ldarg.0
+IL_00f4:  ldloc.s    V_7
+IL_00f6:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__2'
+IL_00fb:  ldarg.0
+IL_00fc:  stloc.s    V_5
+IL_00fe:  ldarg.0
+IL_00ff:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0104:  ldloca.s   V_7
+IL_0106:  ldloca.s   V_5
+IL_0108:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&,
+!!1&)
+IL_010d:  nop
+IL_010e:  leave      IL_023a
+IL_0113:  ldarg.0
+IL_0114:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__2'
+IL_0119:  stloc.s    V_7
+IL_011b:  ldarg.0
+IL_011c:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__2'
+IL_0121:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0127:  ldarg.0
+IL_0128:  ldc.i4.m1
+IL_0129:  dup
+IL_012a:  stloc.0
+IL_012b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0130:  ldloca.s   V_7
+IL_0132:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0137:  nop
+IL_0138:  ldarg.0
+IL_0139:  ldarg.0
+IL_013a:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__2'
+IL_013f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>s__5'
+IL_0144:  ldarg.0
+IL_0145:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_014a:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_014f:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0154:  stloc.s    V_4
+IL_0156:  ldloca.s   V_4
+IL_0158:  ldc.i4.0
+IL_0159:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_015e:  stloc.s    V_8
+IL_0160:  ldloca.s   V_8
+IL_0162:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0167:  stloc.s    V_10
+IL_0169:  ldloca.s   V_10
+IL_016b:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0170:  brtrue.s   IL_01b8
+IL_0172:  ldarg.0
+IL_0173:  ldc.i4.2
+IL_0174:  dup
+IL_0175:  stloc.0
+IL_0176:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_017b:  ldarg.0
+IL_017c:  ldloc.s    V_10
+IL_017e:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_0183:  ldarg.0
+IL_0184:  stloc.s    V_5
+IL_0186:  ldarg.0
+IL_0187:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_018c:  ldloca.s   V_10
+IL_018e:  ldloca.s   V_5
+IL_0190:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,class AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&,
+!!1&)
+IL_0195:  nop
+IL_0196:  leave      IL_023a
+IL_019b:  ldarg.0
+IL_019c:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_01a1:  stloc.s    V_10
+IL_01a3:  ldarg.0
+IL_01a4:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_01a9:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_01af:  ldarg.0
+IL_01b0:  ldc.i4.m1
+IL_01b1:  dup
+IL_01b2:  stloc.0
+IL_01b3:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_01b8:  ldarg.0
+IL_01b9:  ldloca.s   V_10
+IL_01bb:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_01c0:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>s__6'
+IL_01c5:  ldarg.0
+IL_01c6:  ldarg.0
+IL_01c7:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>s__5'
+IL_01cc:  ldarg.0
+IL_01cd:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>s__6'
+IL_01d2:  add
+IL_01d3:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__2'
+IL_01d8:  nop
+IL_01d9:  ldarg.0
+IL_01da:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_01df:  stloc.s    V_11
+IL_01e1:  ldarg.0
+IL_01e2:  ldloc.s    V_11
+IL_01e4:  ldc.i4.1
+IL_01e5:  add
+IL_01e6:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_01eb:  ldarg.0
+IL_01ec:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_01f1:  ldarg.0
+IL_01f2:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<count>5__1'
+IL_01f7:  clt
+IL_01f9:  stloc.s    V_12
+IL_01fb:  ldloc.s    V_12
+IL_01fd:  brtrue     IL_00c0
+IL_0202:  ldarg.0
+IL_0203:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__2'
+IL_0208:  stloc.1
+IL_0209:  leave.s    IL_0225
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_020b:  stloc.s    V_13
+IL_020d:  ldarg.0
+IL_020e:  ldc.i4.s   -2
+IL_0210:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0215:  ldarg.0
+IL_0216:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_021b:  ldloc.s    V_13
+IL_021d:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_0222:  nop
+IL_0223:  leave.s    IL_023a
+}  // end handler
+IL_0225:  ldarg.0
+IL_0226:  ldc.i4.s   -2
+IL_0228:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_022d:  ldarg.0
+IL_022e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0233:  ldloc.1
+IL_0234:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_0239:  nop
+IL_023a:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod9_WithValueTask>d__20'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private int32 '<count>5__1'
+.field private int32 '<sum>5__2'
+.field private int32 '<>s__3'
+.field private int32 '<i>5__4'
+.field private int32 '<>s__5'
+.field private int32 '<>s__6'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__2'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_4,
+class AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20' V_5,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_6,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_7,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_8,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_9,
+int32 V_10,
+bool V_11,
+class [System.Runtime]System.Exception V_12)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  switch     (
+IL_001b,
+IL_001d,
+IL_0022)
+IL_0019:  br.s       IL_0027
+IL_001b:  br.s       IL_0078
+IL_001d:  br         IL_0113
+IL_0022:  br         IL_019a
+IL_0027:  nop
+IL_0028:  ldc.i4.s   10
+IL_002a:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_002f:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0034:  stloc.3
+IL_0035:  ldloca.s   V_3
+IL_0037:  ldc.i4.0
+IL_0038:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_003d:  stloc.s    V_4
+IL_003f:  ldloca.s   V_4
+IL_0041:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0046:  stloc.2
+IL_0047:  ldloca.s   V_2
+IL_0049:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_004e:  brtrue.s   IL_0094
+IL_0050:  ldarg.0
+IL_0051:  ldc.i4.0
+IL_0052:  dup
+IL_0053:  stloc.0
+IL_0054:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0059:  ldarg.0
+IL_005a:  ldloc.2
+IL_005b:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_0060:  ldarg.0
+IL_0061:  stloc.s    V_5
+IL_0063:  ldarg.0
+IL_0064:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0069:  ldloca.s   V_2
+IL_006b:  ldloca.s   V_5
+IL_006d:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,class AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&,
+!!1&)
+IL_0072:  nop
+IL_0073:  leave      IL_0239
+IL_0078:  ldarg.0
+IL_0079:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_007e:  stloc.2
+IL_007f:  ldarg.0
+IL_0080:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_0085:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_008b:  ldarg.0
+IL_008c:  ldc.i4.m1
+IL_008d:  dup
+IL_008e:  stloc.0
+IL_008f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0094:  ldarg.0
+IL_0095:  ldloca.s   V_2
+IL_0097:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_009c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>s__3'
+IL_00a1:  ldarg.0
+IL_00a2:  ldarg.0
+IL_00a3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>s__3'
+IL_00a8:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<count>5__1'
+IL_00ad:  ldarg.0
+IL_00ae:  ldc.i4.0
+IL_00af:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__2'
+IL_00b4:  ldarg.0
+IL_00b5:  ldc.i4.0
+IL_00b6:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_00bb:  br         IL_01ea
+IL_00c0:  nop
+IL_00c1:  ldc.i4.1
+IL_00c2:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00c7:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_00cc:  stloc.s    V_7
+IL_00ce:  ldloca.s   V_7
+IL_00d0:  ldc.i4.0
+IL_00d1:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_00d6:  stloc.s    V_8
+IL_00d8:  ldloca.s   V_8
+IL_00da:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_00df:  stloc.s    V_6
+IL_00e1:  ldloca.s   V_6
+IL_00e3:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_00e8:  brtrue.s   IL_0130
+IL_00ea:  ldarg.0
+IL_00eb:  ldc.i4.1
+IL_00ec:  dup
+IL_00ed:  stloc.0
+IL_00ee:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_00f3:  ldarg.0
+IL_00f4:  ldloc.s    V_6
+IL_00f6:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__2'
+IL_00fb:  ldarg.0
+IL_00fc:  stloc.s    V_5
+IL_00fe:  ldarg.0
+IL_00ff:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0104:  ldloca.s   V_6
+IL_0106:  ldloca.s   V_5
+IL_0108:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&,
+!!1&)
+IL_010d:  nop
+IL_010e:  leave      IL_0239
+IL_0113:  ldarg.0
+IL_0114:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__2'
+IL_0119:  stloc.s    V_6
+IL_011b:  ldarg.0
+IL_011c:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__2'
+IL_0121:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0127:  ldarg.0
+IL_0128:  ldc.i4.m1
+IL_0129:  dup
+IL_012a:  stloc.0
+IL_012b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0130:  ldloca.s   V_6
+IL_0132:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0137:  nop
+IL_0138:  ldarg.0
+IL_0139:  ldarg.0
+IL_013a:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__2'
+IL_013f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>s__5'
+IL_0144:  ldarg.0
+IL_0145:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_014a:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_014f:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0154:  stloc.3
+IL_0155:  ldloca.s   V_3
+IL_0157:  ldc.i4.0
+IL_0158:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_015d:  stloc.s    V_4
+IL_015f:  ldloca.s   V_4
+IL_0161:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0166:  stloc.s    V_9
+IL_0168:  ldloca.s   V_9
+IL_016a:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_016f:  brtrue.s   IL_01b7
+IL_0171:  ldarg.0
+IL_0172:  ldc.i4.2
+IL_0173:  dup
+IL_0174:  stloc.0
+IL_0175:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_017a:  ldarg.0
+IL_017b:  ldloc.s    V_9
+IL_017d:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_0182:  ldarg.0
+IL_0183:  stloc.s    V_5
+IL_0185:  ldarg.0
+IL_0186:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_018b:  ldloca.s   V_9
+IL_018d:  ldloca.s   V_5
+IL_018f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,class AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&,
+!!1&)
+IL_0194:  nop
+IL_0195:  leave      IL_0239
+IL_019a:  ldarg.0
+IL_019b:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_01a0:  stloc.s    V_9
+IL_01a2:  ldarg.0
+IL_01a3:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_01a8:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_01ae:  ldarg.0
+IL_01af:  ldc.i4.m1
+IL_01b0:  dup
+IL_01b1:  stloc.0
+IL_01b2:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_01b7:  ldarg.0
+IL_01b8:  ldloca.s   V_9
+IL_01ba:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_01bf:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>s__6'
+IL_01c4:  ldarg.0
+IL_01c5:  ldarg.0
+IL_01c6:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>s__5'
+IL_01cb:  ldarg.0
+IL_01cc:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>s__6'
+IL_01d1:  add
+IL_01d2:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__2'
+IL_01d7:  nop
+IL_01d8:  ldarg.0
+IL_01d9:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_01de:  stloc.s    V_10
+IL_01e0:  ldarg.0
+IL_01e1:  ldloc.s    V_10
+IL_01e3:  ldc.i4.1
+IL_01e4:  add
+IL_01e5:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_01ea:  ldarg.0
+IL_01eb:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_01f0:  ldarg.0
+IL_01f1:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<count>5__1'
+IL_01f6:  clt
+IL_01f8:  stloc.s    V_11
+IL_01fa:  ldloc.s    V_11
+IL_01fc:  brtrue     IL_00c0
+IL_0201:  ldarg.0
+IL_0202:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__2'
+IL_0207:  stloc.1
+IL_0208:  leave.s    IL_0224
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_020a:  stloc.s    V_12
+IL_020c:  ldarg.0
+IL_020d:  ldc.i4.s   -2
+IL_020f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0214:  ldarg.0
+IL_0215:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_021a:  ldloc.s    V_12
+IL_021c:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_0221:  nop
+IL_0222:  leave.s    IL_0239
+}  // end handler
+IL_0224:  ldarg.0
+IL_0225:  ldc.i4.s   -2
+IL_0227:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_022c:  ldarg.0
+IL_022d:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0232:  ldloc.1
+IL_0233:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_0238:  nop
+IL_0239:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod10_WithValueTask>d__21'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private class AssemblyToProcess.Example '<result>5__1'
+.field private class AssemblyToProcess.Example '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AssemblyToProcess.Example V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example> V_3,
+class AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21' V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_0055
+IL_000e:  nop
+IL_000f:  newobj     instance void AssemblyToProcess.Example::.ctor()
+IL_0014:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<class AssemblyToProcess.Example>(!!0)
+IL_0019:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_001e:  stloc.3
+IL_001f:  ldloca.s   V_3
+IL_0021:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::GetAwaiter()
+IL_0026:  stloc.2
+IL_0027:  ldloca.s   V_2
+IL_0029:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>::get_IsCompleted()
+IL_002e:  brtrue.s   IL_0071
+IL_0030:  ldarg.0
+IL_0031:  ldc.i4.0
+IL_0032:  dup
+IL_0033:  stloc.0
+IL_0034:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0039:  ldarg.0
+IL_003a:  ldloc.2
+IL_003b:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>u__1'
+IL_0040:  ldarg.0
+IL_0041:  stloc.s    V_4
+IL_0043:  ldarg.0
+IL_0044:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0049:  ldloca.s   V_2
+IL_004b:  ldloca.s   V_4
+IL_004d:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>,class AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'>(!!0&,
+!!1&)
+IL_0052:  nop
+IL_0053:  leave.s    IL_00c9
+IL_0055:  ldarg.0
+IL_0056:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>u__1'
+IL_005b:  stloc.2
+IL_005c:  ldarg.0
+IL_005d:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>u__1'
+IL_0062:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>
+IL_0068:  ldarg.0
+IL_0069:  ldc.i4.m1
+IL_006a:  dup
+IL_006b:  stloc.0
+IL_006c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0071:  ldarg.0
+IL_0072:  ldloca.s   V_2
+IL_0074:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>::GetResult()
+IL_0079:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>s__2'
+IL_007e:  ldarg.0
+IL_007f:  ldarg.0
+IL_0080:  ldfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>s__2'
+IL_0085:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<result>5__1'
+IL_008a:  ldarg.0
+IL_008b:  ldnull
+IL_008c:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>s__2'
+IL_0091:  ldarg.0
+IL_0092:  ldfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<result>5__1'
+IL_0097:  stloc.1
+IL_0098:  leave.s    IL_00b4
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_009a:  stloc.s    V_5
+IL_009c:  ldarg.0
+IL_009d:  ldc.i4.s   -2
+IL_009f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_00a4:  ldarg.0
+IL_00a5:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_00aa:  ldloc.s    V_5
+IL_00ac:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetException(class [System.Runtime]System.Exception)
+IL_00b1:  nop
+IL_00b2:  leave.s    IL_00c9
+}  // end handler
+IL_00b4:  ldarg.0
+IL_00b5:  ldc.i4.s   -2
+IL_00b7:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_00bc:  ldarg.0
+IL_00bd:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_00c2:  ldloc.1
+IL_00c3:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetResult(!0)
+IL_00c8:  nop
+IL_00c9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod11_WithValueTask>d__22'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private class AssemblyToProcess.Example '<result>5__1'
+.field private class AssemblyToProcess.Example '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AssemblyToProcess.Example V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example> V_4,
+class AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005f
+IL_000e:  nop
+IL_000f:  newobj     instance void AssemblyToProcess.Example::.ctor()
+IL_0014:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<class AssemblyToProcess.Example>(!!0)
+IL_0019:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_001e:  stloc.s    V_4
+IL_0020:  ldloca.s   V_4
+IL_0022:  ldc.i4.0
+IL_0023:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::ConfigureAwait(bool)
+IL_0028:  stloc.3
+IL_0029:  ldloca.s   V_3
+IL_002b:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example>::GetAwaiter()
+IL_0030:  stloc.2
+IL_0031:  ldloca.s   V_2
+IL_0033:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::get_IsCompleted()
+IL_0038:  brtrue.s   IL_007b
+IL_003a:  ldarg.0
+IL_003b:  ldc.i4.0
+IL_003c:  dup
+IL_003d:  stloc.0
+IL_003e:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_0043:  ldarg.0
+IL_0044:  ldloc.2
+IL_0045:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>u__1'
+IL_004a:  ldarg.0
+IL_004b:  stloc.s    V_5
+IL_004d:  ldarg.0
+IL_004e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_0053:  ldloca.s   V_2
+IL_0055:  ldloca.s   V_5
+IL_0057:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>,class AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'>(!!0&,
+!!1&)
+IL_005c:  nop
+IL_005d:  leave.s    IL_00d3
+IL_005f:  ldarg.0
+IL_0060:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>u__1'
+IL_0065:  stloc.2
+IL_0066:  ldarg.0
+IL_0067:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>u__1'
+IL_006c:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>
+IL_0072:  ldarg.0
+IL_0073:  ldc.i4.m1
+IL_0074:  dup
+IL_0075:  stloc.0
+IL_0076:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_007b:  ldarg.0
+IL_007c:  ldloca.s   V_2
+IL_007e:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::GetResult()
+IL_0083:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>s__2'
+IL_0088:  ldarg.0
+IL_0089:  ldarg.0
+IL_008a:  ldfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>s__2'
+IL_008f:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<result>5__1'
+IL_0094:  ldarg.0
+IL_0095:  ldnull
+IL_0096:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>s__2'
+IL_009b:  ldarg.0
+IL_009c:  ldfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<result>5__1'
+IL_00a1:  stloc.1
+IL_00a2:  leave.s    IL_00be
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00a4:  stloc.s    V_6
+IL_00a6:  ldarg.0
+IL_00a7:  ldc.i4.s   -2
+IL_00a9:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_00ae:  ldarg.0
+IL_00af:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_00b4:  ldloc.s    V_6
+IL_00b6:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetException(class [System.Runtime]System.Exception)
+IL_00bb:  nop
+IL_00bc:  leave.s    IL_00d3
+}  // end handler
+IL_00be:  ldarg.0
+IL_00bf:  ldc.i4.s   -2
+IL_00c1:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_00c6:  ldarg.0
+IL_00c7:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_00cc:  ldloc.1
+IL_00cd:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetResult(!0)
+IL_00d2:  nop
+IL_00d3:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod12_WithValueTask>d__23'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> '<>t__builder'
+.field public class AssemblyToProcess.Example '<>4__this'
+.field private class AssemblyToProcess.Example '<result>5__1'
+.field private class AssemblyToProcess.Example '<>s__2'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AssemblyToProcess.Example V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example> V_4,
+class AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005f
+IL_000e:  nop
+IL_000f:  newobj     instance void AssemblyToProcess.Example::.ctor()
+IL_0014:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<class AssemblyToProcess.Example>(!!0)
+IL_0019:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_001e:  stloc.3
+IL_001f:  ldloca.s   V_3
+IL_0021:  ldc.i4.0
+IL_0022:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::ConfigureAwait(bool)
+IL_0027:  stloc.s    V_4
+IL_0029:  ldloca.s   V_4
+IL_002b:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example>::GetAwaiter()
+IL_0030:  stloc.2
+IL_0031:  ldloca.s   V_2
+IL_0033:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::get_IsCompleted()
+IL_0038:  brtrue.s   IL_007b
+IL_003a:  ldarg.0
+IL_003b:  ldc.i4.0
+IL_003c:  dup
+IL_003d:  stloc.0
+IL_003e:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_0043:  ldarg.0
+IL_0044:  ldloc.2
+IL_0045:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>u__1'
+IL_004a:  ldarg.0
+IL_004b:  stloc.s    V_5
+IL_004d:  ldarg.0
+IL_004e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_0053:  ldloca.s   V_2
+IL_0055:  ldloca.s   V_5
+IL_0057:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>,class AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'>(!!0&,
+!!1&)
+IL_005c:  nop
+IL_005d:  leave.s    IL_00d3
+IL_005f:  ldarg.0
+IL_0060:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>u__1'
+IL_0065:  stloc.2
+IL_0066:  ldarg.0
+IL_0067:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>u__1'
+IL_006c:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>
+IL_0072:  ldarg.0
+IL_0073:  ldc.i4.m1
+IL_0074:  dup
+IL_0075:  stloc.0
+IL_0076:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_007b:  ldarg.0
+IL_007c:  ldloca.s   V_2
+IL_007e:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::GetResult()
+IL_0083:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>s__2'
+IL_0088:  ldarg.0
+IL_0089:  ldarg.0
+IL_008a:  ldfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>s__2'
+IL_008f:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<result>5__1'
+IL_0094:  ldarg.0
+IL_0095:  ldnull
+IL_0096:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>s__2'
+IL_009b:  ldarg.0
+IL_009c:  ldfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<result>5__1'
+IL_00a1:  stloc.1
+IL_00a2:  leave.s    IL_00be
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00a4:  stloc.s    V_6
+IL_00a6:  ldarg.0
+IL_00a7:  ldc.i4.s   -2
+IL_00a9:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_00ae:  ldarg.0
+IL_00af:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_00b4:  ldloc.s    V_6
+IL_00b6:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetException(class [System.Runtime]System.Exception)
+IL_00bb:  nop
+IL_00bc:  leave.s    IL_00d3
+}  // end handler
+IL_00be:  ldarg.0
+IL_00bf:  ldc.i4.s   -2
+IL_00c1:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_00c6:  ldarg.0
+IL_00c7:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_00cc:  ldloc.1
+IL_00cd:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetResult(!0)
+IL_00d2:  nop
+IL_00d3:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 AsyncMethod1() cil managed
 {
@@ -2220,6 +4133,381 @@ IL_0028:  ldloca.s   V_0
 IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<class AssemblyToProcess.Example/'<AsyncMethod12>d__11'>(!!0&)
 IL_002f:  ldloc.0
 IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12>d__11'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AsyncMethod1_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 5F 57 69 74 68 56   // yncMethod1_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 32 00 00 ) // alueTask>d__12..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AsyncMethod2_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 32 5F 57 69 74 68 56   // yncMethod2_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 33 00 00 ) // alueTask>d__13..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AsyncMethod3_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 33 5F 57 69 74 68 56   // yncMethod3_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 34 00 00 ) // alueTask>d__14..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod4_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 34 5F 57 69 74 68 56   // yncMethod4_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 35 00 00 ) // alueTask>d__15..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<class AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod5_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 35 5F 57 69 74 68 56   // yncMethod5_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 36 00 00 ) // alueTask>d__16..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<class AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod6_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 36 5F 57 69 74 68 56   // yncMethod6_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 37 00 00 ) // alueTask>d__17..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<class AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod7_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 37 5F 57 69 74 68 56   // yncMethod7_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 38 00 00 ) // alueTask>d__18..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<class AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod8_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 38 5F 57 69 74 68 56   // yncMethod8_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 39 00 00 ) // alueTask>d__19..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<class AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod9_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 39 5F 57 69 74 68 56   // yncMethod9_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 30 00 00 ) // alueTask>d__20..
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<class AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<class AssemblyToProcess.Example>
+AsyncMethod10_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 30 5F 57 69 74 68   // yncMethod10_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 31 00   // ValueTask>d__21.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<class AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<class AssemblyToProcess.Example>
+AsyncMethod11_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 31 5F 57 69 74 68   // yncMethod11_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 32 00   // ValueTask>d__22.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<class AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
+IL_003a:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<class AssemblyToProcess.Example>
+AsyncMethod12_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 32 5F 57 69 74 68   // yncMethod12_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 33 00   // ValueTask>d__23.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Example AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Create()
+IL_0013:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_0018:  ldloc.0
+IL_0019:  ldc.i4.m1
+IL_001a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_001f:  ldloc.0
+IL_0020:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_0025:  stloc.1
+IL_0026:  ldloca.s   V_1
+IL_0028:  ldloca.s   V_0
+IL_002a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<class AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'>(!!0&)
+IL_002f:  ldloc.0
+IL_0030:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
 IL_0035:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
 IL_003a:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileExample_Release.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileExample_Release.approved.txt
@@ -1532,6 +1532,1601 @@ IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runt
 IL_000c:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod1_WithValueTask>d__12'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_2,
+class [System.Runtime]System.Exception V_3)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0047
+IL_000a:  ldc.i4.1
+IL_000b:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0010:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0015:  stloc.2
+IL_0016:  ldloca.s   V_2
+IL_0018:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::GetAwaiter()
+IL_001d:  stloc.1
+IL_001e:  ldloca.s   V_1
+IL_0020:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::get_IsCompleted()
+IL_0025:  brtrue.s   IL_0063
+IL_0027:  ldarg.0
+IL_0028:  ldc.i4.0
+IL_0029:  dup
+IL_002a:  stloc.0
+IL_002b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0030:  ldarg.0
+IL_0031:  ldloc.1
+IL_0032:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>u__1'
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_003d:  ldloca.s   V_1
+IL_003f:  ldarg.0
+IL_0040:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter,valuetype AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'>(!!0&,
+!!1&)
+IL_0045:  leave.s    IL_0096
+IL_0047:  ldarg.0
+IL_0048:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>u__1'
+IL_004d:  stloc.1
+IL_004e:  ldarg.0
+IL_004f:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>u__1'
+IL_0054:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter
+IL_005a:  ldarg.0
+IL_005b:  ldc.i4.m1
+IL_005c:  dup
+IL_005d:  stloc.0
+IL_005e:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0063:  ldloca.s   V_1
+IL_0065:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter::GetResult()
+IL_006a:  leave.s    IL_0083
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_006c:  stloc.3
+IL_006d:  ldarg.0
+IL_006e:  ldc.i4.s   -2
+IL_0070:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0075:  ldarg.0
+IL_0076:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_007b:  ldloc.3
+IL_007c:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0081:  leave.s    IL_0096
+}  // end handler
+IL_0083:  ldarg.0
+IL_0084:  ldc.i4.s   -2
+IL_0086:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_008b:  ldarg.0
+IL_008c:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0091:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_0096:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod2_WithValueTask>d__13'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0050
+IL_000a:  ldc.i4.1
+IL_000b:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0010:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_0015:  stloc.3
+IL_0016:  ldloca.s   V_3
+IL_0018:  ldc.i4.0
+IL_0019:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_001e:  stloc.2
+IL_001f:  ldloca.s   V_2
+IL_0021:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0026:  stloc.1
+IL_0027:  ldloca.s   V_1
+IL_0029:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_002e:  brtrue.s   IL_006c
+IL_0030:  ldarg.0
+IL_0031:  ldc.i4.0
+IL_0032:  dup
+IL_0033:  stloc.0
+IL_0034:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_0039:  ldarg.0
+IL_003a:  ldloc.1
+IL_003b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>u__1'
+IL_0040:  ldarg.0
+IL_0041:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0046:  ldloca.s   V_1
+IL_0048:  ldarg.0
+IL_0049:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'>(!!0&,
+!!1&)
+IL_004e:  leave.s    IL_00a1
+IL_0050:  ldarg.0
+IL_0051:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>u__1'
+IL_0056:  stloc.1
+IL_0057:  ldarg.0
+IL_0058:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>u__1'
+IL_005d:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0063:  ldarg.0
+IL_0064:  ldc.i4.m1
+IL_0065:  dup
+IL_0066:  stloc.0
+IL_0067:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_006c:  ldloca.s   V_1
+IL_006e:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0073:  leave.s    IL_008e
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0075:  stloc.s    V_4
+IL_0077:  ldarg.0
+IL_0078:  ldc.i4.s   -2
+IL_007a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_007f:  ldarg.0
+IL_0080:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0085:  ldloc.s    V_4
+IL_0087:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_008c:  leave.s    IL_00a1
+}  // end handler
+IL_008e:  ldarg.0
+IL_008f:  ldc.i4.s   -2
+IL_0091:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_0096:  ldarg.0
+IL_0097:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_009c:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00a1:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod3_WithValueTask>d__14'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0050
+IL_000a:  ldc.i4.1
+IL_000b:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0010:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_0015:  stloc.2
+IL_0016:  ldloca.s   V_2
+IL_0018:  ldc.i4.0
+IL_0019:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_001e:  stloc.3
+IL_001f:  ldloca.s   V_3
+IL_0021:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0026:  stloc.1
+IL_0027:  ldloca.s   V_1
+IL_0029:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_002e:  brtrue.s   IL_006c
+IL_0030:  ldarg.0
+IL_0031:  ldc.i4.0
+IL_0032:  dup
+IL_0033:  stloc.0
+IL_0034:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_0039:  ldarg.0
+IL_003a:  ldloc.1
+IL_003b:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>u__1'
+IL_0040:  ldarg.0
+IL_0041:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0046:  ldloca.s   V_1
+IL_0048:  ldarg.0
+IL_0049:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'>(!!0&,
+!!1&)
+IL_004e:  leave.s    IL_00a1
+IL_0050:  ldarg.0
+IL_0051:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>u__1'
+IL_0056:  stloc.1
+IL_0057:  ldarg.0
+IL_0058:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>u__1'
+IL_005d:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0063:  ldarg.0
+IL_0064:  ldc.i4.m1
+IL_0065:  dup
+IL_0066:  stloc.0
+IL_0067:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_006c:  ldloca.s   V_1
+IL_006e:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0073:  leave.s    IL_008e
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0075:  stloc.s    V_4
+IL_0077:  ldarg.0
+IL_0078:  ldc.i4.s   -2
+IL_007a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_007f:  ldarg.0
+IL_0080:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0085:  ldloc.s    V_4
+IL_0087:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_008c:  leave.s    IL_00a1
+}  // end handler
+IL_008e:  ldarg.0
+IL_008f:  ldc.i4.s   -2
+IL_0091:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_0096:  ldarg.0
+IL_0097:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_009c:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00a1:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod4_WithValueTask>d__15'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0048
+IL_000a:  ldc.i4.s   10
+IL_000c:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0011:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0016:  stloc.3
+IL_0017:  ldloca.s   V_3
+IL_0019:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::GetAwaiter()
+IL_001e:  stloc.2
+IL_001f:  ldloca.s   V_2
+IL_0021:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::get_IsCompleted()
+IL_0026:  brtrue.s   IL_0064
+IL_0028:  ldarg.0
+IL_0029:  ldc.i4.0
+IL_002a:  dup
+IL_002b:  stloc.0
+IL_002c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0031:  ldarg.0
+IL_0032:  ldloc.2
+IL_0033:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>u__1'
+IL_0038:  ldarg.0
+IL_0039:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_003e:  ldloca.s   V_2
+IL_0040:  ldarg.0
+IL_0041:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'>(!!0&,
+!!1&)
+IL_0046:  leave.s    IL_009b
+IL_0048:  ldarg.0
+IL_0049:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>u__1'
+IL_004e:  stloc.2
+IL_004f:  ldarg.0
+IL_0050:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>u__1'
+IL_0055:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>
+IL_005b:  ldarg.0
+IL_005c:  ldc.i4.m1
+IL_005d:  dup
+IL_005e:  stloc.0
+IL_005f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0064:  ldloca.s   V_2
+IL_0066:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::GetResult()
+IL_006b:  stloc.1
+IL_006c:  leave.s    IL_0087
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_006e:  stloc.s    V_4
+IL_0070:  ldarg.0
+IL_0071:  ldc.i4.s   -2
+IL_0073:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0078:  ldarg.0
+IL_0079:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_007e:  ldloc.s    V_4
+IL_0080:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_0085:  leave.s    IL_009b
+}  // end handler
+IL_0087:  ldarg.0
+IL_0088:  ldc.i4.s   -2
+IL_008a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_008f:  ldarg.0
+IL_0090:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_0095:  ldloc.1
+IL_0096:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_009b:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod5_WithValueTask>d__16'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0052
+IL_000a:  ldc.i4.s   10
+IL_000c:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0011:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0016:  stloc.s    V_4
+IL_0018:  ldloca.s   V_4
+IL_001a:  ldc.i4.0
+IL_001b:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_0020:  stloc.3
+IL_0021:  ldloca.s   V_3
+IL_0023:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0028:  stloc.2
+IL_0029:  ldloca.s   V_2
+IL_002b:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0030:  brtrue.s   IL_006e
+IL_0032:  ldarg.0
+IL_0033:  ldc.i4.0
+IL_0034:  dup
+IL_0035:  stloc.0
+IL_0036:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_003b:  ldarg.0
+IL_003c:  ldloc.2
+IL_003d:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>u__1'
+IL_0042:  ldarg.0
+IL_0043:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0048:  ldloca.s   V_2
+IL_004a:  ldarg.0
+IL_004b:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'>(!!0&,
+!!1&)
+IL_0050:  leave.s    IL_00a5
+IL_0052:  ldarg.0
+IL_0053:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>u__1'
+IL_0058:  stloc.2
+IL_0059:  ldarg.0
+IL_005a:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>u__1'
+IL_005f:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_0065:  ldarg.0
+IL_0066:  ldc.i4.m1
+IL_0067:  dup
+IL_0068:  stloc.0
+IL_0069:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_006e:  ldloca.s   V_2
+IL_0070:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0075:  stloc.1
+IL_0076:  leave.s    IL_0091
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0078:  stloc.s    V_5
+IL_007a:  ldarg.0
+IL_007b:  ldc.i4.s   -2
+IL_007d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0082:  ldarg.0
+IL_0083:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0088:  ldloc.s    V_5
+IL_008a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_008f:  leave.s    IL_00a5
+}  // end handler
+IL_0091:  ldarg.0
+IL_0092:  ldc.i4.s   -2
+IL_0094:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0099:  ldarg.0
+IL_009a:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_009f:  ldloc.1
+IL_00a0:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_00a5:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod6_WithValueTask>d__17'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0052
+IL_000a:  ldc.i4.s   10
+IL_000c:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0011:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0016:  stloc.3
+IL_0017:  ldloca.s   V_3
+IL_0019:  ldc.i4.0
+IL_001a:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_001f:  stloc.s    V_4
+IL_0021:  ldloca.s   V_4
+IL_0023:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0028:  stloc.2
+IL_0029:  ldloca.s   V_2
+IL_002b:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0030:  brtrue.s   IL_006e
+IL_0032:  ldarg.0
+IL_0033:  ldc.i4.0
+IL_0034:  dup
+IL_0035:  stloc.0
+IL_0036:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_003b:  ldarg.0
+IL_003c:  ldloc.2
+IL_003d:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>u__1'
+IL_0042:  ldarg.0
+IL_0043:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0048:  ldloca.s   V_2
+IL_004a:  ldarg.0
+IL_004b:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'>(!!0&,
+!!1&)
+IL_0050:  leave.s    IL_00a5
+IL_0052:  ldarg.0
+IL_0053:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>u__1'
+IL_0058:  stloc.2
+IL_0059:  ldarg.0
+IL_005a:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>u__1'
+IL_005f:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_0065:  ldarg.0
+IL_0066:  ldc.i4.m1
+IL_0067:  dup
+IL_0068:  stloc.0
+IL_0069:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_006e:  ldloca.s   V_2
+IL_0070:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0075:  stloc.1
+IL_0076:  leave.s    IL_0091
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0078:  stloc.s    V_5
+IL_007a:  ldarg.0
+IL_007b:  ldc.i4.s   -2
+IL_007d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0082:  ldarg.0
+IL_0083:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0088:  ldloc.s    V_5
+IL_008a:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_008f:  leave.s    IL_00a5
+}  // end handler
+IL_0091:  ldarg.0
+IL_0092:  ldc.i4.s   -2
+IL_0094:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0099:  ldarg.0
+IL_009a:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_009f:  ldloc.1
+IL_00a0:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_00a5:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod7_WithValueTask>d__18'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field private int32 '<count>5__2'
+.field private int32 '<sum>5__3'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> '<>u__1'
+.field private int32 '<i>5__4'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter '<>u__2'
+.field private int32 '<>7__wrap4'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> '<>u__3'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+int32 V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_4,
+valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter V_5,
+valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> V_6,
+class [System.Runtime]System.Exception V_7)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  switch     (
+IL_005b,
+IL_00d3,
+IL_0142)
+IL_0019:  ldc.i4.s   10
+IL_001b:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0020:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0025:  stloc.s    V_4
+IL_0027:  ldloca.s   V_4
+IL_0029:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::GetAwaiter()
+IL_002e:  stloc.3
+IL_002f:  ldloca.s   V_3
+IL_0031:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::get_IsCompleted()
+IL_0036:  brtrue.s   IL_0077
+IL_0038:  ldarg.0
+IL_0039:  ldc.i4.0
+IL_003a:  dup
+IL_003b:  stloc.0
+IL_003c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0041:  ldarg.0
+IL_0042:  ldloc.3
+IL_0043:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__1'
+IL_0048:  ldarg.0
+IL_0049:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_004e:  ldloca.s   V_3
+IL_0050:  ldarg.0
+IL_0051:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&,
+!!1&)
+IL_0056:  leave      IL_01cc
+IL_005b:  ldarg.0
+IL_005c:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__1'
+IL_0061:  stloc.3
+IL_0062:  ldarg.0
+IL_0063:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__1'
+IL_0068:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>
+IL_006e:  ldarg.0
+IL_006f:  ldc.i4.m1
+IL_0070:  dup
+IL_0071:  stloc.0
+IL_0072:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0077:  ldloca.s   V_3
+IL_0079:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<int32>::GetResult()
+IL_007e:  stloc.2
+IL_007f:  ldarg.0
+IL_0080:  ldloc.2
+IL_0081:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<count>5__2'
+IL_0086:  ldarg.0
+IL_0087:  ldc.i4.0
+IL_0088:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__3'
+IL_008d:  ldarg.0
+IL_008e:  ldc.i4.0
+IL_008f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_0094:  br         IL_0185
+IL_0099:  ldc.i4.1
+IL_009a:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_009f:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter [System.Runtime]System.Threading.Tasks.Task::GetAwaiter()
+IL_00a4:  stloc.s    V_5
+IL_00a6:  ldloca.s   V_5
+IL_00a8:  call       instance bool [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter::get_IsCompleted()
+IL_00ad:  brtrue.s   IL_00f0
+IL_00af:  ldarg.0
+IL_00b0:  ldc.i4.1
+IL_00b1:  dup
+IL_00b2:  stloc.0
+IL_00b3:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_00b8:  ldarg.0
+IL_00b9:  ldloc.s    V_5
+IL_00bb:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__2'
+IL_00c0:  ldarg.0
+IL_00c1:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_00c6:  ldloca.s   V_5
+IL_00c8:  ldarg.0
+IL_00c9:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter,valuetype AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&,
+!!1&)
+IL_00ce:  leave      IL_01cc
+IL_00d3:  ldarg.0
+IL_00d4:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__2'
+IL_00d9:  stloc.s    V_5
+IL_00db:  ldarg.0
+IL_00dc:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__2'
+IL_00e1:  initobj    [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter
+IL_00e7:  ldarg.0
+IL_00e8:  ldc.i4.m1
+IL_00e9:  dup
+IL_00ea:  stloc.0
+IL_00eb:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_00f0:  ldloca.s   V_5
+IL_00f2:  call       instance void [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter::GetResult()
+IL_00f7:  ldarg.0
+IL_00f8:  ldarg.0
+IL_00f9:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__3'
+IL_00fe:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>7__wrap4'
+IL_0103:  ldarg.0
+IL_0104:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_0109:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_010e:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<!0> class [System.Runtime]System.Threading.Tasks.Task`1<int32>::GetAwaiter()
+IL_0113:  stloc.s    V_6
+IL_0115:  ldloca.s   V_6
+IL_0117:  call       instance bool valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>::get_IsCompleted()
+IL_011c:  brtrue.s   IL_015f
+IL_011e:  ldarg.0
+IL_011f:  ldc.i4.2
+IL_0120:  dup
+IL_0121:  stloc.0
+IL_0122:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0127:  ldarg.0
+IL_0128:  ldloc.s    V_6
+IL_012a:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__3'
+IL_012f:  ldarg.0
+IL_0130:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_0135:  ldloca.s   V_6
+IL_0137:  ldarg.0
+IL_0138:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&,
+!!1&)
+IL_013d:  leave      IL_01cc
+IL_0142:  ldarg.0
+IL_0143:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__3'
+IL_0148:  stloc.s    V_6
+IL_014a:  ldarg.0
+IL_014b:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>u__3'
+IL_0150:  initobj    valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>
+IL_0156:  ldarg.0
+IL_0157:  ldc.i4.m1
+IL_0158:  dup
+IL_0159:  stloc.0
+IL_015a:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_015f:  ldloca.s   V_6
+IL_0161:  call       instance !0 valuetype [System.Runtime]System.Runtime.CompilerServices.TaskAwaiter`1<int32>::GetResult()
+IL_0166:  stloc.2
+IL_0167:  ldarg.0
+IL_0168:  ldarg.0
+IL_0169:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>7__wrap4'
+IL_016e:  ldloc.2
+IL_016f:  add
+IL_0170:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__3'
+IL_0175:  ldarg.0
+IL_0176:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_017b:  stloc.2
+IL_017c:  ldarg.0
+IL_017d:  ldloc.2
+IL_017e:  ldc.i4.1
+IL_017f:  add
+IL_0180:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_0185:  ldarg.0
+IL_0186:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<i>5__4'
+IL_018b:  ldarg.0
+IL_018c:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<count>5__2'
+IL_0191:  blt        IL_0099
+IL_0196:  ldarg.0
+IL_0197:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<sum>5__3'
+IL_019c:  stloc.1
+IL_019d:  leave.s    IL_01b8
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_019f:  stloc.s    V_7
+IL_01a1:  ldarg.0
+IL_01a2:  ldc.i4.s   -2
+IL_01a4:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_01a9:  ldarg.0
+IL_01aa:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_01af:  ldloc.s    V_7
+IL_01b1:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_01b6:  leave.s    IL_01cc
+}  // end handler
+IL_01b8:  ldarg.0
+IL_01b9:  ldc.i4.s   -2
+IL_01bb:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_01c0:  ldarg.0
+IL_01c1:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_01c6:  ldloc.1
+IL_01c7:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_01cc:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod8_WithValueTask>d__19'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field private int32 '<count>5__2'
+.field private int32 '<sum>5__3'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.field private int32 '<i>5__4'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__2'
+.field private int32 '<>7__wrap4'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+int32 V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_3,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_4,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_5,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_6,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_7,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_8,
+class [System.Runtime]System.Exception V_9)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  switch     (
+IL_0065,
+IL_00f0,
+IL_0170)
+IL_0019:  ldc.i4.s   10
+IL_001b:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0020:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0025:  stloc.s    V_5
+IL_0027:  ldloca.s   V_5
+IL_0029:  ldc.i4.0
+IL_002a:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_002f:  stloc.s    V_4
+IL_0031:  ldloca.s   V_4
+IL_0033:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0038:  stloc.3
+IL_0039:  ldloca.s   V_3
+IL_003b:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0040:  brtrue.s   IL_0081
+IL_0042:  ldarg.0
+IL_0043:  ldc.i4.0
+IL_0044:  dup
+IL_0045:  stloc.0
+IL_0046:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_004b:  ldarg.0
+IL_004c:  ldloc.3
+IL_004d:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0058:  ldloca.s   V_3
+IL_005a:  ldarg.0
+IL_005b:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&,
+!!1&)
+IL_0060:  leave      IL_01f9
+IL_0065:  ldarg.0
+IL_0066:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_006b:  stloc.3
+IL_006c:  ldarg.0
+IL_006d:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_0072:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_0078:  ldarg.0
+IL_0079:  ldc.i4.m1
+IL_007a:  dup
+IL_007b:  stloc.0
+IL_007c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0081:  ldloca.s   V_3
+IL_0083:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0088:  stloc.2
+IL_0089:  ldarg.0
+IL_008a:  ldloc.2
+IL_008b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<count>5__2'
+IL_0090:  ldarg.0
+IL_0091:  ldc.i4.0
+IL_0092:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__3'
+IL_0097:  ldarg.0
+IL_0098:  ldc.i4.0
+IL_0099:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_009e:  br         IL_01b2
+IL_00a3:  ldc.i4.1
+IL_00a4:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00a9:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_00ae:  stloc.s    V_8
+IL_00b0:  ldloca.s   V_8
+IL_00b2:  ldc.i4.0
+IL_00b3:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_00b8:  stloc.s    V_6
+IL_00ba:  ldloca.s   V_6
+IL_00bc:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_00c1:  stloc.s    V_7
+IL_00c3:  ldloca.s   V_7
+IL_00c5:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_00ca:  brtrue.s   IL_010d
+IL_00cc:  ldarg.0
+IL_00cd:  ldc.i4.1
+IL_00ce:  dup
+IL_00cf:  stloc.0
+IL_00d0:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_00d5:  ldarg.0
+IL_00d6:  ldloc.s    V_7
+IL_00d8:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__2'
+IL_00dd:  ldarg.0
+IL_00de:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_00e3:  ldloca.s   V_7
+IL_00e5:  ldarg.0
+IL_00e6:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&,
+!!1&)
+IL_00eb:  leave      IL_01f9
+IL_00f0:  ldarg.0
+IL_00f1:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__2'
+IL_00f6:  stloc.s    V_7
+IL_00f8:  ldarg.0
+IL_00f9:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__2'
+IL_00fe:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0104:  ldarg.0
+IL_0105:  ldc.i4.m1
+IL_0106:  dup
+IL_0107:  stloc.0
+IL_0108:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_010d:  ldloca.s   V_7
+IL_010f:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0114:  ldarg.0
+IL_0115:  ldarg.0
+IL_0116:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__3'
+IL_011b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>7__wrap4'
+IL_0120:  ldarg.0
+IL_0121:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_0126:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_012b:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0130:  stloc.s    V_5
+IL_0132:  ldloca.s   V_5
+IL_0134:  ldc.i4.0
+IL_0135:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_013a:  stloc.s    V_4
+IL_013c:  ldloca.s   V_4
+IL_013e:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0143:  stloc.3
+IL_0144:  ldloca.s   V_3
+IL_0146:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_014b:  brtrue.s   IL_018c
+IL_014d:  ldarg.0
+IL_014e:  ldc.i4.2
+IL_014f:  dup
+IL_0150:  stloc.0
+IL_0151:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0156:  ldarg.0
+IL_0157:  ldloc.3
+IL_0158:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_015d:  ldarg.0
+IL_015e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0163:  ldloca.s   V_3
+IL_0165:  ldarg.0
+IL_0166:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&,
+!!1&)
+IL_016b:  leave      IL_01f9
+IL_0170:  ldarg.0
+IL_0171:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_0176:  stloc.3
+IL_0177:  ldarg.0
+IL_0178:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>u__1'
+IL_017d:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_0183:  ldarg.0
+IL_0184:  ldc.i4.m1
+IL_0185:  dup
+IL_0186:  stloc.0
+IL_0187:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_018c:  ldloca.s   V_3
+IL_018e:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0193:  stloc.2
+IL_0194:  ldarg.0
+IL_0195:  ldarg.0
+IL_0196:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>7__wrap4'
+IL_019b:  ldloc.2
+IL_019c:  add
+IL_019d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__3'
+IL_01a2:  ldarg.0
+IL_01a3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_01a8:  stloc.2
+IL_01a9:  ldarg.0
+IL_01aa:  ldloc.2
+IL_01ab:  ldc.i4.1
+IL_01ac:  add
+IL_01ad:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_01b2:  ldarg.0
+IL_01b3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<i>5__4'
+IL_01b8:  ldarg.0
+IL_01b9:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<count>5__2'
+IL_01be:  blt        IL_00a3
+IL_01c3:  ldarg.0
+IL_01c4:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<sum>5__3'
+IL_01c9:  stloc.1
+IL_01ca:  leave.s    IL_01e5
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_01cc:  stloc.s    V_9
+IL_01ce:  ldarg.0
+IL_01cf:  ldc.i4.s   -2
+IL_01d1:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_01d6:  ldarg.0
+IL_01d7:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_01dc:  ldloc.s    V_9
+IL_01de:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_01e3:  leave.s    IL_01f9
+}  // end handler
+IL_01e5:  ldarg.0
+IL_01e6:  ldc.i4.s   -2
+IL_01e8:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_01ed:  ldarg.0
+IL_01ee:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_01f3:  ldloc.1
+IL_01f4:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_01f9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod9_WithValueTask>d__20'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> '<>t__builder'
+.field private int32 '<count>5__2'
+.field private int32 '<sum>5__3'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> '<>u__1'
+.field private int32 '<i>5__4'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__2'
+.field private int32 '<>7__wrap4'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+int32 V_1,
+int32 V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32> V_4,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32> V_5,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_6,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_7,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_8,
+class [System.Runtime]System.Exception V_9)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  switch     (
+IL_0065,
+IL_00f0,
+IL_0170)
+IL_0019:  ldc.i4.s   10
+IL_001b:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_0020:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0025:  stloc.s    V_4
+IL_0027:  ldloca.s   V_4
+IL_0029:  ldc.i4.0
+IL_002a:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_002f:  stloc.s    V_5
+IL_0031:  ldloca.s   V_5
+IL_0033:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0038:  stloc.3
+IL_0039:  ldloca.s   V_3
+IL_003b:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_0040:  brtrue.s   IL_0081
+IL_0042:  ldarg.0
+IL_0043:  ldc.i4.0
+IL_0044:  dup
+IL_0045:  stloc.0
+IL_0046:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_004b:  ldarg.0
+IL_004c:  ldloc.3
+IL_004d:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0058:  ldloca.s   V_3
+IL_005a:  ldarg.0
+IL_005b:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&,
+!!1&)
+IL_0060:  leave      IL_01f9
+IL_0065:  ldarg.0
+IL_0066:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_006b:  stloc.3
+IL_006c:  ldarg.0
+IL_006d:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_0072:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_0078:  ldarg.0
+IL_0079:  ldc.i4.m1
+IL_007a:  dup
+IL_007b:  stloc.0
+IL_007c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0081:  ldloca.s   V_3
+IL_0083:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0088:  stloc.2
+IL_0089:  ldarg.0
+IL_008a:  ldloc.2
+IL_008b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<count>5__2'
+IL_0090:  ldarg.0
+IL_0091:  ldc.i4.0
+IL_0092:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__3'
+IL_0097:  ldarg.0
+IL_0098:  ldc.i4.0
+IL_0099:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_009e:  br         IL_01b2
+IL_00a3:  ldc.i4.1
+IL_00a4:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00a9:  newobj     instance void [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Task)
+IL_00ae:  stloc.s    V_7
+IL_00b0:  ldloca.s   V_7
+IL_00b2:  ldc.i4.0
+IL_00b3:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_00b8:  stloc.s    V_8
+IL_00ba:  ldloca.s   V_8
+IL_00bc:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_00c1:  stloc.s    V_6
+IL_00c3:  ldloca.s   V_6
+IL_00c5:  call       instance bool [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_00ca:  brtrue.s   IL_010d
+IL_00cc:  ldarg.0
+IL_00cd:  ldc.i4.1
+IL_00ce:  dup
+IL_00cf:  stloc.0
+IL_00d0:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_00d5:  ldarg.0
+IL_00d6:  ldloc.s    V_6
+IL_00d8:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__2'
+IL_00dd:  ldarg.0
+IL_00de:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_00e3:  ldloca.s   V_6
+IL_00e5:  ldarg.0
+IL_00e6:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&,
+!!1&)
+IL_00eb:  leave      IL_01f9
+IL_00f0:  ldarg.0
+IL_00f1:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__2'
+IL_00f6:  stloc.s    V_6
+IL_00f8:  ldarg.0
+IL_00f9:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__2'
+IL_00fe:  initobj    [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0104:  ldarg.0
+IL_0105:  ldc.i4.m1
+IL_0106:  dup
+IL_0107:  stloc.0
+IL_0108:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_010d:  ldloca.s   V_6
+IL_010f:  call       instance void [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0114:  ldarg.0
+IL_0115:  ldarg.0
+IL_0116:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__3'
+IL_011b:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>7__wrap4'
+IL_0120:  ldarg.0
+IL_0121:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_0126:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<int32>(!!0)
+IL_012b:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0130:  stloc.s    V_4
+IL_0132:  ldloca.s   V_4
+IL_0134:  ldc.i4.0
+IL_0135:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<int32>::ConfigureAwait(bool)
+IL_013a:  stloc.s    V_5
+IL_013c:  ldloca.s   V_5
+IL_013e:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<int32>::GetAwaiter()
+IL_0143:  stloc.3
+IL_0144:  ldloca.s   V_3
+IL_0146:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::get_IsCompleted()
+IL_014b:  brtrue.s   IL_018c
+IL_014d:  ldarg.0
+IL_014e:  ldc.i4.2
+IL_014f:  dup
+IL_0150:  stloc.0
+IL_0151:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0156:  ldarg.0
+IL_0157:  ldloc.3
+IL_0158:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_015d:  ldarg.0
+IL_015e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0163:  ldloca.s   V_3
+IL_0165:  ldarg.0
+IL_0166:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>,valuetype AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&,
+!!1&)
+IL_016b:  leave      IL_01f9
+IL_0170:  ldarg.0
+IL_0171:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_0176:  stloc.3
+IL_0177:  ldarg.0
+IL_0178:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>u__1'
+IL_017d:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>
+IL_0183:  ldarg.0
+IL_0184:  ldc.i4.m1
+IL_0185:  dup
+IL_0186:  stloc.0
+IL_0187:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_018c:  ldloca.s   V_3
+IL_018e:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<int32>::GetResult()
+IL_0193:  stloc.2
+IL_0194:  ldarg.0
+IL_0195:  ldarg.0
+IL_0196:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>7__wrap4'
+IL_019b:  ldloc.2
+IL_019c:  add
+IL_019d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__3'
+IL_01a2:  ldarg.0
+IL_01a3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_01a8:  stloc.2
+IL_01a9:  ldarg.0
+IL_01aa:  ldloc.2
+IL_01ab:  ldc.i4.1
+IL_01ac:  add
+IL_01ad:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_01b2:  ldarg.0
+IL_01b3:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<i>5__4'
+IL_01b8:  ldarg.0
+IL_01b9:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<count>5__2'
+IL_01be:  blt        IL_00a3
+IL_01c3:  ldarg.0
+IL_01c4:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<sum>5__3'
+IL_01c9:  stloc.1
+IL_01ca:  leave.s    IL_01e5
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_01cc:  stloc.s    V_9
+IL_01ce:  ldarg.0
+IL_01cf:  ldc.i4.s   -2
+IL_01d1:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_01d6:  ldarg.0
+IL_01d7:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_01dc:  ldloc.s    V_9
+IL_01de:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetException(class [System.Runtime]System.Exception)
+IL_01e3:  leave.s    IL_01f9
+}  // end handler
+IL_01e5:  ldarg.0
+IL_01e6:  ldc.i4.s   -2
+IL_01e8:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_01ed:  ldarg.0
+IL_01ee:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_01f3:  ldloc.1
+IL_01f4:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetResult(!0)
+IL_01f9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod10_WithValueTask>d__21'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AssemblyToProcess.Example V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example> V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_004b
+IL_000a:  newobj     instance void AssemblyToProcess.Example::.ctor()
+IL_000f:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<class AssemblyToProcess.Example>(!!0)
+IL_0014:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0019:  stloc.3
+IL_001a:  ldloca.s   V_3
+IL_001c:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::GetAwaiter()
+IL_0021:  stloc.2
+IL_0022:  ldloca.s   V_2
+IL_0024:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>::get_IsCompleted()
+IL_0029:  brtrue.s   IL_0067
+IL_002b:  ldarg.0
+IL_002c:  ldc.i4.0
+IL_002d:  dup
+IL_002e:  stloc.0
+IL_002f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0034:  ldarg.0
+IL_0035:  ldloc.2
+IL_0036:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>u__1'
+IL_003b:  ldarg.0
+IL_003c:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0041:  ldloca.s   V_2
+IL_0043:  ldarg.0
+IL_0044:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>,valuetype AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'>(!!0&,
+!!1&)
+IL_0049:  leave.s    IL_009e
+IL_004b:  ldarg.0
+IL_004c:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>u__1'
+IL_0051:  stloc.2
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>u__1'
+IL_0058:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>
+IL_005e:  ldarg.0
+IL_005f:  ldc.i4.m1
+IL_0060:  dup
+IL_0061:  stloc.0
+IL_0062:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0067:  ldloca.s   V_2
+IL_0069:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ValueTaskAwaiter`1<class AssemblyToProcess.Example>::GetResult()
+IL_006e:  stloc.1
+IL_006f:  leave.s    IL_008a
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0071:  stloc.s    V_4
+IL_0073:  ldarg.0
+IL_0074:  ldc.i4.s   -2
+IL_0076:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_007b:  ldarg.0
+IL_007c:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0081:  ldloc.s    V_4
+IL_0083:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetException(class [System.Runtime]System.Exception)
+IL_0088:  leave.s    IL_009e
+}  // end handler
+IL_008a:  ldarg.0
+IL_008b:  ldc.i4.s   -2
+IL_008d:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0092:  ldarg.0
+IL_0093:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0098:  ldloc.1
+IL_0099:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetResult(!0)
+IL_009e:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod11_WithValueTask>d__22'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> '<>t__builder'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AssemblyToProcess.Example V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example> V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0055
+IL_000a:  newobj     instance void AssemblyToProcess.Example::.ctor()
+IL_000f:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<class AssemblyToProcess.Example>(!!0)
+IL_0014:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0019:  stloc.s    V_4
+IL_001b:  ldloca.s   V_4
+IL_001d:  ldc.i4.0
+IL_001e:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::ConfigureAwait(bool)
+IL_0023:  stloc.3
+IL_0024:  ldloca.s   V_3
+IL_0026:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example>::GetAwaiter()
+IL_002b:  stloc.2
+IL_002c:  ldloca.s   V_2
+IL_002e:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::get_IsCompleted()
+IL_0033:  brtrue.s   IL_0071
+IL_0035:  ldarg.0
+IL_0036:  ldc.i4.0
+IL_0037:  dup
+IL_0038:  stloc.0
+IL_0039:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_003e:  ldarg.0
+IL_003f:  ldloc.2
+IL_0040:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>u__1'
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_004b:  ldloca.s   V_2
+IL_004d:  ldarg.0
+IL_004e:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>,valuetype AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'>(!!0&,
+!!1&)
+IL_0053:  leave.s    IL_00a8
+IL_0055:  ldarg.0
+IL_0056:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>u__1'
+IL_005b:  stloc.2
+IL_005c:  ldarg.0
+IL_005d:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>u__1'
+IL_0062:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>
+IL_0068:  ldarg.0
+IL_0069:  ldc.i4.m1
+IL_006a:  dup
+IL_006b:  stloc.0
+IL_006c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_0071:  ldloca.s   V_2
+IL_0073:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::GetResult()
+IL_0078:  stloc.1
+IL_0079:  leave.s    IL_0094
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_007b:  stloc.s    V_5
+IL_007d:  ldarg.0
+IL_007e:  ldc.i4.s   -2
+IL_0080:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_0085:  ldarg.0
+IL_0086:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_008b:  ldloc.s    V_5
+IL_008d:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetException(class [System.Runtime]System.Exception)
+IL_0092:  leave.s    IL_00a8
+}  // end handler
+IL_0094:  ldarg.0
+IL_0095:  ldc.i4.s   -2
+IL_0097:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_009c:  ldarg.0
+IL_009d:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_00a2:  ldloc.1
+IL_00a3:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetResult(!0)
+IL_00a8:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AsyncMethod12_WithValueTask>d__23'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> '<>t__builder'
+.field private valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AssemblyToProcess.Example V_1,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example> V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example> V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0055
+IL_000a:  newobj     instance void AssemblyToProcess.Example::.ctor()
+IL_000f:  call       class [System.Runtime]System.Threading.Tasks.Task`1<!!0> [System.Runtime]System.Threading.Tasks.Task::FromResult<class AssemblyToProcess.Example>(!!0)
+IL_0014:  newobj     instance void valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::.ctor(class [System.Runtime]System.Threading.Tasks.Task`1<!0>)
+IL_0019:  stloc.3
+IL_001a:  ldloca.s   V_3
+IL_001c:  ldc.i4.0
+IL_001d:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<class AssemblyToProcess.Example>::ConfigureAwait(bool)
+IL_0022:  stloc.s    V_4
+IL_0024:  ldloca.s   V_4
+IL_0026:  call       instance valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<class AssemblyToProcess.Example>::GetAwaiter()
+IL_002b:  stloc.2
+IL_002c:  ldloca.s   V_2
+IL_002e:  call       instance bool valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::get_IsCompleted()
+IL_0033:  brtrue.s   IL_0071
+IL_0035:  ldarg.0
+IL_0036:  ldc.i4.0
+IL_0037:  dup
+IL_0038:  stloc.0
+IL_0039:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_003e:  ldarg.0
+IL_003f:  ldloc.2
+IL_0040:  stfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>u__1'
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_004b:  ldloca.s   V_2
+IL_004d:  ldarg.0
+IL_004e:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::AwaitUnsafeOnCompleted<valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>,valuetype AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'>(!!0&,
+!!1&)
+IL_0053:  leave.s    IL_00a8
+IL_0055:  ldarg.0
+IL_0056:  ldfld      valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>u__1'
+IL_005b:  stloc.2
+IL_005c:  ldarg.0
+IL_005d:  ldflda     valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>u__1'
+IL_0062:  initobj    valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>
+IL_0068:  ldarg.0
+IL_0069:  ldc.i4.m1
+IL_006a:  dup
+IL_006b:  stloc.0
+IL_006c:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_0071:  ldloca.s   V_2
+IL_0073:  call       instance !0 valuetype [System.Threading.Tasks.Extensions]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<class AssemblyToProcess.Example>::GetResult()
+IL_0078:  stloc.1
+IL_0079:  leave.s    IL_0094
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_007b:  stloc.s    V_5
+IL_007d:  ldarg.0
+IL_007e:  ldc.i4.s   -2
+IL_0080:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_0085:  ldarg.0
+IL_0086:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_008b:  ldloc.s    V_5
+IL_008d:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetException(class [System.Runtime]System.Exception)
+IL_0092:  leave.s    IL_00a8
+}  // end handler
+IL_0094:  ldarg.0
+IL_0095:  ldc.i4.s   -2
+IL_0097:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_009c:  ldarg.0
+IL_009d:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_00a2:  ldloc.1
+IL_00a3:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetResult(!0)
+IL_00a8:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 AsyncMethod1() cil managed
 {
@@ -1841,6 +3436,321 @@ IL_001d:  ldloca.s   V_0
 IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod12>d__11'>(!!0&)
 IL_0024:  ldloca.s   V_0
 IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12>d__11'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AsyncMethod1_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 5F 57 69 74 68 56   // yncMethod1_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 32 00 00 ) // alueTask>d__12..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod1_WithValueTask>d__12'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AsyncMethod2_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 32 5F 57 69 74 68 56   // yncMethod2_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 33 00 00 ) // alueTask>d__13..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod2_WithValueTask>d__13'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AsyncMethod3_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 33 5F 57 69 74 68 56   // yncMethod3_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 34 00 00 ) // alueTask>d__14..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Example/'<AsyncMethod3_WithValueTask>d__14'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod4_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 34 5F 57 69 74 68 56   // yncMethod4_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 35 00 00 ) // alueTask>d__15..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod4_WithValueTask>d__15'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod5_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 35 5F 57 69 74 68 56   // yncMethod5_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 36 00 00 ) // alueTask>d__16..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod5_WithValueTask>d__16'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod6_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 36 5F 57 69 74 68 56   // yncMethod6_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 37 00 00 ) // alueTask>d__17..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod6_WithValueTask>d__17'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod7_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 37 5F 57 69 74 68 56   // yncMethod7_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 38 00 00 ) // alueTask>d__18..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod7_WithValueTask>d__18'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod8_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 38 5F 57 69 74 68 56   // yncMethod8_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 39 00 00 ) // alueTask>d__19..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod8_WithValueTask>d__19'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<int32>
+AsyncMethod9_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 39 5F 57 69 74 68 56   // yncMethod9_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 30 00 00 ) // alueTask>d__20..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32> AssemblyToProcess.Example/'<AsyncMethod9_WithValueTask>d__20'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<int32>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<class AssemblyToProcess.Example>
+AsyncMethod10_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 30 5F 57 69 74 68   // yncMethod10_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 31 00   // ValueTask>d__21.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod10_WithValueTask>d__21'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<class AssemblyToProcess.Example>
+AsyncMethod11_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 31 5F 57 69 74 68   // yncMethod11_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 32 00   // ValueTask>d__22.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod11_WithValueTask>d__22'::'<>t__builder'
+IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
+IL_0030:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task`1<class AssemblyToProcess.Example>
+AsyncMethod12_WithValueTask() cil managed
+{
+63 65 73 73 2E 45 78 61 6D 70 6C 65 2B 3C 41 73   // cess.Example+<As
+79 6E 63 4D 65 74 68 6F 64 31 32 5F 57 69 74 68   // yncMethod12_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 32 33 00   // ValueTask>d__23.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Create()
+IL_0007:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldc.i4.m1
+IL_000f:  stfld      int32 AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>1__state'
+IL_0014:  ldloc.0
+IL_0015:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
+IL_001a:  stloc.1
+IL_001b:  ldloca.s   V_1
+IL_001d:  ldloca.s   V_0
+IL_001f:  call       instance void valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::Start<valuetype AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'>(!!0&)
+IL_0024:  ldloca.s   V_0
+IL_0026:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example> AssemblyToProcess.Example/'<AsyncMethod12_WithValueTask>d__23'::'<>t__builder'
 IL_002b:  call       instance class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<class AssemblyToProcess.Example>::get_Task()
 IL_0030:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileGenericClass_Debug.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileGenericClass_Debug.approved.txt
@@ -124,6 +124,133 @@ instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.Comp
 IL_0000:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<Method_WithValueTask>d__1'<TItem>
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask
+.field public class AssemblyToProcess.GenericClass`1<!TItem> '<>4__this'
+.field private !TItem '<item>5__1'
+.field private !TItem '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<!TItem> V_3,
+class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem> V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005a
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::itemTask
+IL_0015:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_001a:  stloc.3
+IL_001b:  ldloca.s   V_3
+IL_001d:  ldc.i4.0
+IL_001e:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!TItem>::ConfigureAwait(bool)
+IL_0023:  stloc.2
+IL_0024:  ldloca.s   V_2
+IL_0026:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::GetAwaiter()
+IL_002b:  stloc.1
+IL_002c:  ldloca.s   V_1
+IL_002e:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::get_IsCompleted()
+IL_0033:  brtrue.s   IL_0076
+IL_0035:  ldarg.0
+IL_0036:  ldc.i4.0
+IL_0037:  dup
+IL_0038:  stloc.0
+IL_0039:  stfld      int32 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_003e:  ldarg.0
+IL_003f:  ldloc.1
+IL_0040:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>u__1'
+IL_0045:  ldarg.0
+IL_0046:  stloc.s    V_4
+IL_0048:  ldarg.0
+IL_0049:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_004e:  ldloca.s   V_1
+IL_0050:  ldloca.s   V_4
+IL_0052:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>,class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>>(!!0&,
+!!1&)
+IL_0057:  nop
+IL_0058:  leave.s    IL_00cb
+IL_005a:  ldarg.0
+IL_005b:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>u__1'
+IL_0060:  stloc.1
+IL_0061:  ldarg.0
+IL_0062:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>u__1'
+IL_0067:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>
+IL_006d:  ldarg.0
+IL_006e:  ldc.i4.m1
+IL_006f:  dup
+IL_0070:  stloc.0
+IL_0071:  stfld      int32 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0076:  ldarg.0
+IL_0077:  ldloca.s   V_1
+IL_0079:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::GetResult()
+IL_007e:  stfld      !0 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>s__2'
+IL_0083:  ldarg.0
+IL_0084:  ldarg.0
+IL_0085:  ldfld      !0 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>s__2'
+IL_008a:  stfld      !0 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<item>5__1'
+IL_008f:  ldarg.0
+IL_0090:  ldflda     !0 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>s__2'
+IL_0095:  initobj    !TItem
+IL_009b:  leave.s    IL_00b7
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_009d:  stloc.s    V_5
+IL_009f:  ldarg.0
+IL_00a0:  ldc.i4.s   -2
+IL_00a2:  stfld      int32 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_00a7:  ldarg.0
+IL_00a8:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_00ad:  ldloc.s    V_5
+IL_00af:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00b4:  nop
+IL_00b5:  leave.s    IL_00cb
+}  // end handler
+IL_00b7:  ldarg.0
+IL_00b8:  ldc.i4.s   -2
+IL_00ba:  stfld      int32 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_00bf:  ldarg.0
+IL_00c0:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_00c5:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00ca:  nop
+IL_00cb:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 Method(class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask) cil managed
 {
@@ -155,6 +282,40 @@ IL_002f:  ldloca.s   V_0
 IL_0031:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.GenericClass`1/'<Method>d__0'<!TItem>>(!!0&)
 IL_0036:  ldloc.0
 IL_0037:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method>d__0'<!TItem>::'<>t__builder'
+IL_003c:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0041:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Method_WithValueTask(class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask) cil managed
+{
+63 65 73 73 2E 47 65 6E 65 72 69 63 43 6C 61 73   // cess.GenericClas
+73 60 31 2B 3C 4D 65 74 68 6F 64 5F 57 69 74 68   // s`1+<Method_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 00 00 ) // ValueTask>d__1..
+.maxstack  2
+.locals init (class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem> V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.GenericClass`1<!0> class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  ldarg.1
+IL_000f:  stfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::itemTask
+IL_0014:  ldloc.0
+IL_0015:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_001a:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_001f:  ldloc.0
+IL_0020:  ldc.i4.m1
+IL_0021:  stfld      int32 class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0026:  ldloc.0
+IL_0027:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_002c:  stloc.1
+IL_002d:  ldloca.s   V_1
+IL_002f:  ldloca.s   V_0
+IL_0031:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>>(!!0&)
+IL_0036:  ldloc.0
+IL_0037:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
 IL_003c:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0041:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileGenericClass_Release.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileGenericClass_Release.approved.txt
@@ -99,6 +99,108 @@ IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.Compil
 IL_000c:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<Method_WithValueTask>d__1'<TItem>
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<!TItem> V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0050
+IL_000a:  ldarg.0
+IL_000b:  ldfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::itemTask
+IL_0010:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0015:  stloc.3
+IL_0016:  ldloca.s   V_3
+IL_0018:  ldc.i4.0
+IL_0019:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!TItem>::ConfigureAwait(bool)
+IL_001e:  stloc.2
+IL_001f:  ldloca.s   V_2
+IL_0021:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::GetAwaiter()
+IL_0026:  stloc.1
+IL_0027:  ldloca.s   V_1
+IL_0029:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::get_IsCompleted()
+IL_002e:  brtrue.s   IL_006c
+IL_0030:  ldarg.0
+IL_0031:  ldc.i4.0
+IL_0032:  dup
+IL_0033:  stloc.0
+IL_0034:  stfld      int32 valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0039:  ldarg.0
+IL_003a:  ldloc.1
+IL_003b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>u__1'
+IL_0040:  ldarg.0
+IL_0041:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_0046:  ldloca.s   V_1
+IL_0048:  ldarg.0
+IL_0049:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>,valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>>(!!0&,
+!!1&)
+IL_004e:  leave.s    IL_00a2
+IL_0050:  ldarg.0
+IL_0051:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>u__1'
+IL_0056:  stloc.1
+IL_0057:  ldarg.0
+IL_0058:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>u__1'
+IL_005d:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>
+IL_0063:  ldarg.0
+IL_0064:  ldc.i4.m1
+IL_0065:  dup
+IL_0066:  stloc.0
+IL_0067:  stfld      int32 valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_006c:  ldloca.s   V_1
+IL_006e:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::GetResult()
+IL_0073:  pop
+IL_0074:  leave.s    IL_008f
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0076:  stloc.s    V_4
+IL_0078:  ldarg.0
+IL_0079:  ldc.i4.s   -2
+IL_007b:  stfld      int32 valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0080:  ldarg.0
+IL_0081:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_0086:  ldloc.s    V_4
+IL_0088:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_008d:  leave.s    IL_00a2
+}  // end handler
+IL_008f:  ldarg.0
+IL_0090:  ldc.i4.s   -2
+IL_0092:  stfld      int32 valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_0097:  ldarg.0
+IL_0098:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_009d:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00a2:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 Method(class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask) cil managed
 {
@@ -125,6 +227,35 @@ IL_0025:  ldloca.s   V_0
 IL_0027:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.GenericClass`1/'<Method>d__0'<!TItem>>(!!0&)
 IL_002c:  ldloca.s   V_0
 IL_002e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method>d__0'<!TItem>::'<>t__builder'
+IL_0033:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0038:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Method_WithValueTask(class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask) cil managed
+{
+63 65 73 73 2E 47 65 6E 65 72 69 63 43 6C 61 73   // cess.GenericClas
+73 60 31 2B 3C 4D 65 74 68 6F 64 5F 57 69 74 68   // s`1+<Method_With
+56 61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 00 00 ) // ValueTask>d__1..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem> V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  ldarg.1
+IL_0003:  stfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::itemTask
+IL_0008:  ldloca.s   V_0
+IL_000a:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_000f:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_0014:  ldloca.s   V_0
+IL_0016:  ldc.i4.m1
+IL_0017:  stfld      int32 valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>1__state'
+IL_001c:  ldloc.0
+IL_001d:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
+IL_0022:  stloc.1
+IL_0023:  ldloca.s   V_1
+IL_0025:  ldloca.s   V_0
+IL_0027:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>>(!!0&)
+IL_002c:  ldloca.s   V_0
+IL_002e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericClass`1/'<Method_WithValueTask>d__1'<!TItem>::'<>t__builder'
 IL_0033:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0038:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileGenericMethod_Debug.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileGenericMethod_Debug.approved.txt
@@ -124,6 +124,133 @@ instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.Comp
 IL_0000:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<Method_WithValueTask>d__1`1'<TItem>
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask
+.field public class AssemblyToProcess.GenericMethod '<>4__this'
+.field private !TItem '<item>5__1'
+.field private !TItem '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<!TItem> V_3,
+class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem> V_4,
+class [System.Runtime]System.Exception V_5)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_000e
+IL_000c:  br.s       IL_005a
+IL_000e:  nop
+IL_000f:  ldarg.0
+IL_0010:  ldfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::itemTask
+IL_0015:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_001a:  stloc.3
+IL_001b:  ldloca.s   V_3
+IL_001d:  ldc.i4.0
+IL_001e:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!TItem>::ConfigureAwait(bool)
+IL_0023:  stloc.2
+IL_0024:  ldloca.s   V_2
+IL_0026:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::GetAwaiter()
+IL_002b:  stloc.1
+IL_002c:  ldloca.s   V_1
+IL_002e:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::get_IsCompleted()
+IL_0033:  brtrue.s   IL_0076
+IL_0035:  ldarg.0
+IL_0036:  ldc.i4.0
+IL_0037:  dup
+IL_0038:  stloc.0
+IL_0039:  stfld      int32 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_003e:  ldarg.0
+IL_003f:  ldloc.1
+IL_0040:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>u__1'
+IL_0045:  ldarg.0
+IL_0046:  stloc.s    V_4
+IL_0048:  ldarg.0
+IL_0049:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_004e:  ldloca.s   V_1
+IL_0050:  ldloca.s   V_4
+IL_0052:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>,class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>>(!!0&,
+!!1&)
+IL_0057:  nop
+IL_0058:  leave.s    IL_00cb
+IL_005a:  ldarg.0
+IL_005b:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>u__1'
+IL_0060:  stloc.1
+IL_0061:  ldarg.0
+IL_0062:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>u__1'
+IL_0067:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>
+IL_006d:  ldarg.0
+IL_006e:  ldc.i4.m1
+IL_006f:  dup
+IL_0070:  stloc.0
+IL_0071:  stfld      int32 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_0076:  ldarg.0
+IL_0077:  ldloca.s   V_1
+IL_0079:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::GetResult()
+IL_007e:  stfld      !0 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>s__2'
+IL_0083:  ldarg.0
+IL_0084:  ldarg.0
+IL_0085:  ldfld      !0 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>s__2'
+IL_008a:  stfld      !0 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<item>5__1'
+IL_008f:  ldarg.0
+IL_0090:  ldflda     !0 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>s__2'
+IL_0095:  initobj    !TItem
+IL_009b:  leave.s    IL_00b7
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_009d:  stloc.s    V_5
+IL_009f:  ldarg.0
+IL_00a0:  ldc.i4.s   -2
+IL_00a2:  stfld      int32 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_00a7:  ldarg.0
+IL_00a8:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_00ad:  ldloc.s    V_5
+IL_00af:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00b4:  nop
+IL_00b5:  leave.s    IL_00cb
+}  // end handler
+IL_00b7:  ldarg.0
+IL_00b8:  ldc.i4.s   -2
+IL_00ba:  stfld      int32 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_00bf:  ldarg.0
+IL_00c0:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_00c5:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00ca:  nop
+IL_00cb:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 Method<TItem>(class [System.Runtime]System.Threading.Tasks.Task`1<!!TItem> itemTask) cil managed
 {
@@ -155,6 +282,41 @@ IL_002f:  ldloca.s   V_0
 IL_0031:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.GenericMethod/'<Method>d__0`1'<!!0>>(!!0&)
 IL_0036:  ldloc.0
 IL_0037:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method>d__0`1'<!!TItem>::'<>t__builder'
+IL_003c:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0041:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Method_WithValueTask<TItem>(class [System.Runtime]System.Threading.Tasks.Task`1<!!TItem> itemTask) cil managed
+{
+63 65 73 73 2E 47 65 6E 65 72 69 63 4D 65 74 68   // cess.GenericMeth
+6F 64 2B 3C 4D 65 74 68 6F 64 5F 57 69 74 68 56   // od+<Method_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 60 31 00   // alueTask>d__1`1.
+00 )
+.maxstack  2
+.locals init (class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem> V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.GenericMethod class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  ldarg.1
+IL_000f:  stfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::itemTask
+IL_0014:  ldloc.0
+IL_0015:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_001a:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>t__builder'
+IL_001f:  ldloc.0
+IL_0020:  ldc.i4.m1
+IL_0021:  stfld      int32 class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>1__state'
+IL_0026:  ldloc.0
+IL_0027:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>t__builder'
+IL_002c:  stloc.1
+IL_002d:  ldloca.s   V_1
+IL_002f:  ldloca.s   V_0
+IL_0031:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!0>>(!!0&)
+IL_0036:  ldloc.0
+IL_0037:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder class AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>t__builder'
 IL_003c:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0041:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileGenericMethod_Release.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileGenericMethod_Release.approved.txt
@@ -99,6 +99,108 @@ IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.Compil
 IL_000c:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<Method_WithValueTask>d__1`1'<TItem>
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Runtime]System.Threading.Tasks.Task`1<!TItem> itemTask
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem> V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem> V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<!TItem> V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0050
+IL_000a:  ldarg.0
+IL_000b:  ldfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::itemTask
+IL_0010:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0015:  stloc.3
+IL_0016:  ldloca.s   V_3
+IL_0018:  ldc.i4.0
+IL_0019:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!TItem>::ConfigureAwait(bool)
+IL_001e:  stloc.2
+IL_001f:  ldloca.s   V_2
+IL_0021:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!TItem>::GetAwaiter()
+IL_0026:  stloc.1
+IL_0027:  ldloca.s   V_1
+IL_0029:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::get_IsCompleted()
+IL_002e:  brtrue.s   IL_006c
+IL_0030:  ldarg.0
+IL_0031:  ldc.i4.0
+IL_0032:  dup
+IL_0033:  stloc.0
+IL_0034:  stfld      int32 valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_0039:  ldarg.0
+IL_003a:  ldloc.1
+IL_003b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>u__1'
+IL_0040:  ldarg.0
+IL_0041:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_0046:  ldloca.s   V_1
+IL_0048:  ldarg.0
+IL_0049:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>,valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>>(!!0&,
+!!1&)
+IL_004e:  leave.s    IL_00a2
+IL_0050:  ldarg.0
+IL_0051:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>u__1'
+IL_0056:  stloc.1
+IL_0057:  ldarg.0
+IL_0058:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>u__1'
+IL_005d:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>
+IL_0063:  ldarg.0
+IL_0064:  ldc.i4.m1
+IL_0065:  dup
+IL_0066:  stloc.0
+IL_0067:  stfld      int32 valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_006c:  ldloca.s   V_1
+IL_006e:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!TItem>::GetResult()
+IL_0073:  pop
+IL_0074:  leave.s    IL_008f
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0076:  stloc.s    V_4
+IL_0078:  ldarg.0
+IL_0079:  ldc.i4.s   -2
+IL_007b:  stfld      int32 valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_0080:  ldarg.0
+IL_0081:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_0086:  ldloc.s    V_4
+IL_0088:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_008d:  leave.s    IL_00a2
+}  // end handler
+IL_008f:  ldarg.0
+IL_0090:  ldc.i4.s   -2
+IL_0092:  stfld      int32 valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>1__state'
+IL_0097:  ldarg.0
+IL_0098:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_009d:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00a2:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!TItem>::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
 .method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 Method<TItem>(class [System.Runtime]System.Threading.Tasks.Task`1<!!TItem> itemTask) cil managed
 {
@@ -125,6 +227,36 @@ IL_0025:  ldloca.s   V_0
 IL_0027:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.GenericMethod/'<Method>d__0`1'<!!0>>(!!0&)
 IL_002c:  ldloca.s   V_0
 IL_002e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method>d__0`1'<!!TItem>::'<>t__builder'
+IL_0033:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0038:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Method_WithValueTask<TItem>(class [System.Runtime]System.Threading.Tasks.Task`1<!!TItem> itemTask) cil managed
+{
+63 65 73 73 2E 47 65 6E 65 72 69 63 4D 65 74 68   // cess.GenericMeth
+6F 64 2B 3C 4D 65 74 68 6F 64 5F 57 69 74 68 56   // od+<Method_WithV
+61 6C 75 65 54 61 73 6B 3E 64 5F 5F 31 60 31 00   // alueTask>d__1`1.
+00 )
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem> V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  ldarg.1
+IL_0003:  stfld      class [System.Runtime]System.Threading.Tasks.Task`1<!0> valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::itemTask
+IL_0008:  ldloca.s   V_0
+IL_000a:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_000f:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>t__builder'
+IL_0014:  ldloca.s   V_0
+IL_0016:  ldc.i4.m1
+IL_0017:  stfld      int32 valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>1__state'
+IL_001c:  ldloc.0
+IL_001d:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>t__builder'
+IL_0022:  stloc.1
+IL_0023:  ldloca.s   V_1
+IL_0025:  ldloca.s   V_0
+IL_0027:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!0>>(!!0&)
+IL_002c:  ldloca.s   V_0
+IL_002e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder valuetype AssemblyToProcess.GenericMethod/'<Method_WithValueTask>d__1`1'<!!TItem>::'<>t__builder'
 IL_0033:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0038:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileIssue1_Debug.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileIssue1_Debug.approved.txt
@@ -193,6 +193,206 @@ instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.Comp
 IL_0000:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<WithReaderAndWriter_WithValueTask>d__1'
+extends [System.Runtime]System.Object
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Runtime.Extensions]System.IO.TextWriter writer
+.field public class [System.Runtime.Extensions]System.IO.StreamReader reader
+.field public class AssemblyToProcess.Issue1 '<>4__this'
+.field private string '<line>5__1'
+.field private string '<>s__2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> '<>u__2'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_2,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_3,
+class AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1' V_4,
+bool V_5,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<string> V_6,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> V_7,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<string> V_8,
+string V_9,
+class [System.Runtime]System.Exception V_10)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0012
+IL_000a:  br.s       IL_000c
+IL_000c:  ldloc.0
+IL_000d:  ldc.i4.1
+IL_000e:  beq.s      IL_0014
+IL_0010:  br.s       IL_0019
+IL_0012:  br.s       IL_0079
+IL_0014:  br         IL_00f5
+IL_0019:  nop
+IL_001a:  br         IL_009e
+IL_001f:  nop
+IL_0020:  ldarg.0
+IL_0021:  ldfld      class [System.Runtime.Extensions]System.IO.TextWriter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::writer
+IL_0026:  ldarg.0
+IL_0027:  ldfld      string AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<line>5__1'
+IL_002c:  callvirt   instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime.Extensions]System.IO.TextWriter::WriteLineAsync(string)
+IL_0031:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_0036:  stloc.3
+IL_0037:  ldloca.s   V_3
+IL_0039:  ldc.i4.0
+IL_003a:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_003f:  stloc.2
+IL_0040:  ldloca.s   V_2
+IL_0042:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0047:  stloc.1
+IL_0048:  ldloca.s   V_1
+IL_004a:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_004f:  brtrue.s   IL_0095
+IL_0051:  ldarg.0
+IL_0052:  ldc.i4.0
+IL_0053:  dup
+IL_0054:  stloc.0
+IL_0055:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_005a:  ldarg.0
+IL_005b:  ldloc.1
+IL_005c:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__1'
+IL_0061:  ldarg.0
+IL_0062:  stloc.s    V_4
+IL_0064:  ldarg.0
+IL_0065:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_006a:  ldloca.s   V_1
+IL_006c:  ldloca.s   V_4
+IL_006e:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'>(!!0&,
+!!1&)
+IL_0073:  nop
+IL_0074:  leave      IL_0173
+IL_0079:  ldarg.0
+IL_007a:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__1'
+IL_007f:  stloc.1
+IL_0080:  ldarg.0
+IL_0081:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__1'
+IL_0086:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_008c:  ldarg.0
+IL_008d:  ldc.i4.m1
+IL_008e:  dup
+IL_008f:  stloc.0
+IL_0090:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0095:  ldloca.s   V_1
+IL_0097:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_009c:  nop
+IL_009d:  nop
+IL_009e:  ldarg.0
+IL_009f:  ldfld      class [System.Runtime.Extensions]System.IO.StreamReader AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::reader
+IL_00a4:  callvirt   instance class [System.Runtime]System.Threading.Tasks.Task`1<string> [System.Runtime.Extensions]System.IO.TextReader::ReadLineAsync()
+IL_00a9:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<string>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_00ae:  stloc.s    V_8
+IL_00b0:  ldloca.s   V_8
+IL_00b2:  ldc.i4.0
+IL_00b3:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<string>::ConfigureAwait(bool)
+IL_00b8:  stloc.s    V_6
+IL_00ba:  ldloca.s   V_6
+IL_00bc:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<string>::GetAwaiter()
+IL_00c1:  stloc.s    V_7
+IL_00c3:  ldloca.s   V_7
+IL_00c5:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>::get_IsCompleted()
+IL_00ca:  brtrue.s   IL_0112
+IL_00cc:  ldarg.0
+IL_00cd:  ldc.i4.1
+IL_00ce:  dup
+IL_00cf:  stloc.0
+IL_00d0:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_00d5:  ldarg.0
+IL_00d6:  ldloc.s    V_7
+IL_00d8:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__2'
+IL_00dd:  ldarg.0
+IL_00de:  stloc.s    V_4
+IL_00e0:  ldarg.0
+IL_00e1:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_00e6:  ldloca.s   V_7
+IL_00e8:  ldloca.s   V_4
+IL_00ea:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>,class AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'>(!!0&,
+!!1&)
+IL_00ef:  nop
+IL_00f0:  leave      IL_0173
+IL_00f5:  ldarg.0
+IL_00f6:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__2'
+IL_00fb:  stloc.s    V_7
+IL_00fd:  ldarg.0
+IL_00fe:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__2'
+IL_0103:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>
+IL_0109:  ldarg.0
+IL_010a:  ldc.i4.m1
+IL_010b:  dup
+IL_010c:  stloc.0
+IL_010d:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0112:  ldarg.0
+IL_0113:  ldloca.s   V_7
+IL_0115:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>::GetResult()
+IL_011a:  stfld      string AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>s__2'
+IL_011f:  ldarg.0
+IL_0120:  ldarg.0
+IL_0121:  ldfld      string AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>s__2'
+IL_0126:  dup
+IL_0127:  stloc.s    V_9
+IL_0129:  stfld      string AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<line>5__1'
+IL_012e:  ldloc.s    V_9
+IL_0130:  ldnull
+IL_0131:  cgt.un
+IL_0133:  stloc.s    V_5
+IL_0135:  ldloc.s    V_5
+IL_0137:  brtrue     IL_001f
+IL_013c:  ldarg.0
+IL_013d:  ldnull
+IL_013e:  stfld      string AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>s__2'
+IL_0143:  leave.s    IL_015f
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0145:  stloc.s    V_10
+IL_0147:  ldarg.0
+IL_0148:  ldc.i4.s   -2
+IL_014a:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_014f:  ldarg.0
+IL_0150:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0155:  ldloc.s    V_10
+IL_0157:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_015c:  nop
+IL_015d:  leave.s    IL_0173
+}  // end handler
+IL_015f:  ldarg.0
+IL_0160:  ldc.i4.s   -2
+IL_0162:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0167:  ldarg.0
+IL_0168:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_016d:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_0172:  nop
+IL_0173:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
 .method private hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 WithReaderAndWriter(class [System.Runtime.Extensions]System.IO.TextWriter writer,
 class [System.Runtime.Extensions]System.IO.StreamReader reader) cil managed
@@ -228,6 +428,45 @@ IL_0036:  ldloca.s   V_0
 IL_0038:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.Issue1/'<WithReaderAndWriter>d__0'>(!!0&)
 IL_003d:  ldloc.0
 IL_003e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter>d__0'::'<>t__builder'
+IL_0043:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0048:  ret
+}
+.method private hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+WithReaderAndWriter_WithValueTask(class [System.Runtime.Extensions]System.IO.TextWriter writer,
+class [System.Runtime.Extensions]System.IO.StreamReader reader) cil managed
+{
+63 65 73 73 2E 49 73 73 75 65 31 2B 3C 57 69 74   // cess.Issue1+<Wit
+68 52 65 61 64 65 72 41 6E 64 57 72 69 74 65 72   // hReaderAndWriter
+5F 57 69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64   // _WithValueTask>d
+5F 5F 31 00 00 )                                  // __1..
+.maxstack  2
+.locals init (class AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  newobj     instance void AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  ldarg.0
+IL_0008:  stfld      class AssemblyToProcess.Issue1 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>4__this'
+IL_000d:  ldloc.0
+IL_000e:  ldarg.1
+IL_000f:  stfld      class [System.Runtime.Extensions]System.IO.TextWriter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::writer
+IL_0014:  ldloc.0
+IL_0015:  ldarg.2
+IL_0016:  stfld      class [System.Runtime.Extensions]System.IO.StreamReader AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::reader
+IL_001b:  ldloc.0
+IL_001c:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0021:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0026:  ldloc.0
+IL_0027:  ldc.i4.m1
+IL_0028:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_002d:  ldloc.0
+IL_002e:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0033:  stloc.1
+IL_0034:  ldloca.s   V_1
+IL_0036:  ldloca.s   V_0
+IL_0038:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'>(!!0&)
+IL_003d:  ldloc.0
+IL_003e:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
 IL_0043:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0048:  ret
 }

--- a/Tests/ModuleWeaverTests.DecompileIssue1_Release.approved.txt
+++ b/Tests/ModuleWeaverTests.DecompileIssue1_Release.approved.txt
@@ -152,6 +152,165 @@ IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.Compil
 IL_000c:  ret
 }
 }
+.class auto ansi sealed nested private beforefieldinit '<WithReaderAndWriter_WithValueTask>d__1'
+extends [System.Runtime]System.ValueType
+implements [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Runtime.Extensions]System.IO.TextWriter writer
+.field public class [System.Runtime.Extensions]System.IO.StreamReader reader
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> '<>u__2'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+string V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask V_4,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<string> V_5,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> V_6,
+valuetype [System.Threading.Tasks.Extensions]System.Threading.Tasks.ValueTask`1<string> V_7,
+class [System.Runtime]System.Exception V_8)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0063
+IL_000a:  ldloc.0
+IL_000b:  ldc.i4.1
+IL_000c:  beq        IL_00d5
+IL_0011:  br.s       IL_0086
+IL_0013:  ldarg.0
+IL_0014:  ldfld      class [System.Runtime.Extensions]System.IO.TextWriter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::writer
+IL_0019:  ldloc.1
+IL_001a:  callvirt   instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime.Extensions]System.IO.TextWriter::WriteLineAsync(string)
+IL_001f:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask)
+IL_0024:  stloc.s    V_4
+IL_0026:  ldloca.s   V_4
+IL_0028:  ldc.i4.0
+IL_0029:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_002e:  stloc.3
+IL_002f:  ldloca.s   V_3
+IL_0031:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0036:  stloc.2
+IL_0037:  ldloca.s   V_2
+IL_0039:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_003e:  brtrue.s   IL_007f
+IL_0040:  ldarg.0
+IL_0041:  ldc.i4.0
+IL_0042:  dup
+IL_0043:  stloc.0
+IL_0044:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0049:  ldarg.0
+IL_004a:  ldloc.2
+IL_004b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__1'
+IL_0050:  ldarg.0
+IL_0051:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0056:  ldloca.s   V_2
+IL_0058:  ldarg.0
+IL_0059:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'>(!!0&,
+!!1&)
+IL_005e:  leave      IL_012e
+IL_0063:  ldarg.0
+IL_0064:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__1'
+IL_0069:  stloc.2
+IL_006a:  ldarg.0
+IL_006b:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__1'
+IL_0070:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0076:  ldarg.0
+IL_0077:  ldc.i4.m1
+IL_0078:  dup
+IL_0079:  stloc.0
+IL_007a:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_007f:  ldloca.s   V_2
+IL_0081:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_0086:  ldarg.0
+IL_0087:  ldfld      class [System.Runtime.Extensions]System.IO.StreamReader AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::reader
+IL_008c:  callvirt   instance class [System.Runtime]System.Threading.Tasks.Task`1<string> [System.Runtime.Extensions]System.IO.TextReader::ReadLineAsync()
+IL_0091:  call       instance void valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<string>::.ctor(valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<!0>)
+IL_0096:  stloc.s    V_7
+IL_0098:  ldloca.s   V_7
+IL_009a:  ldc.i4.0
+IL_009b:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<string>::ConfigureAwait(bool)
+IL_00a0:  stloc.s    V_5
+IL_00a2:  ldloca.s   V_5
+IL_00a4:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<string>::GetAwaiter()
+IL_00a9:  stloc.s    V_6
+IL_00ab:  ldloca.s   V_6
+IL_00ad:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>::get_IsCompleted()
+IL_00b2:  brtrue.s   IL_00f2
+IL_00b4:  ldarg.0
+IL_00b5:  ldc.i4.1
+IL_00b6:  dup
+IL_00b7:  stloc.0
+IL_00b8:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_00bd:  ldarg.0
+IL_00be:  ldloc.s    V_6
+IL_00c0:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__2'
+IL_00c5:  ldarg.0
+IL_00c6:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_00cb:  ldloca.s   V_6
+IL_00cd:  ldarg.0
+IL_00ce:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>,valuetype AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'>(!!0&,
+!!1&)
+IL_00d3:  leave.s    IL_012e
+IL_00d5:  ldarg.0
+IL_00d6:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__2'
+IL_00db:  stloc.s    V_6
+IL_00dd:  ldarg.0
+IL_00de:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string> AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>u__2'
+IL_00e3:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>
+IL_00e9:  ldarg.0
+IL_00ea:  ldc.i4.m1
+IL_00eb:  dup
+IL_00ec:  stloc.0
+IL_00ed:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_00f2:  ldloca.s   V_6
+IL_00f4:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<string>::GetResult()
+IL_00f9:  dup
+IL_00fa:  stloc.1
+IL_00fb:  brtrue     IL_0013
+IL_0100:  leave.s    IL_011b
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0102:  stloc.s    V_8
+IL_0104:  ldarg.0
+IL_0105:  ldc.i4.s   -2
+IL_0107:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_010c:  ldarg.0
+IL_010d:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0112:  ldloc.s    V_8
+IL_0114:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0119:  leave.s    IL_012e
+}  // end handler
+IL_011b:  ldarg.0
+IL_011c:  ldc.i4.s   -2
+IL_011e:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0123:  ldarg.0
+IL_0124:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0129:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_012e:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Threading.Tasks]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
 .method private hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
 WithReaderAndWriter(class [System.Runtime.Extensions]System.IO.TextWriter writer,
 class [System.Runtime.Extensions]System.IO.StreamReader reader) cil managed
@@ -182,6 +341,40 @@ IL_002d:  ldloca.s   V_0
 IL_002f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.Issue1/'<WithReaderAndWriter>d__0'>(!!0&)
 IL_0034:  ldloca.s   V_0
 IL_0036:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter>d__0'::'<>t__builder'
+IL_003b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0040:  ret
+}
+.method private hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+WithReaderAndWriter_WithValueTask(class [System.Runtime.Extensions]System.IO.TextWriter writer,
+class [System.Runtime.Extensions]System.IO.StreamReader reader) cil managed
+{
+63 65 73 73 2E 49 73 73 75 65 31 2B 3C 57 69 74   // cess.Issue1+<Wit
+68 52 65 61 64 65 72 41 6E 64 57 72 69 74 65 72   // hReaderAndWriter
+5F 57 69 74 68 56 61 6C 75 65 54 61 73 6B 3E 64   // _WithValueTask>d
+5F 5F 31 00 00 )                                  // __1..
+.maxstack  2
+.locals init (valuetype AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1' V_0,
+valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+IL_0000:  ldloca.s   V_0
+IL_0002:  ldarg.1
+IL_0003:  stfld      class [System.Runtime.Extensions]System.IO.TextWriter AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::writer
+IL_0008:  ldloca.s   V_0
+IL_000a:  ldarg.2
+IL_000b:  stfld      class [System.Runtime.Extensions]System.IO.StreamReader AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::reader
+IL_0010:  ldloca.s   V_0
+IL_0012:  call       valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0017:  stfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_001c:  ldloca.s   V_0
+IL_001e:  ldc.i4.m1
+IL_001f:  stfld      int32 AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>1__state'
+IL_0024:  ldloc.0
+IL_0025:  ldfld      valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
+IL_002a:  stloc.1
+IL_002b:  ldloca.s   V_1
+IL_002d:  ldloca.s   V_0
+IL_002f:  call       instance void [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'>(!!0&)
+IL_0034:  ldloca.s   V_0
+IL_0036:  ldflda     valuetype [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AssemblyToProcess.Issue1/'<WithReaderAndWriter_WithValueTask>d__1'::'<>t__builder'
 IL_003b:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Threading.Tasks]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
 IL_0040:  ret
 }


### PR DESCRIPTION
ValueTask is available for both .NET Standard 2.0 and 2.1, meaning that it is used by both .NET Core and .NET Framework. Only having support for Task is problematic and therefore we have added support for ValueTask also.