### PR TITLE
Add package description

### DIFF
--- a/ConfigureAwait/ConfigureAwait.csproj
+++ b/ConfigureAwait/ConfigureAwait.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <Authors>Cameron MacFarland, Simon Cropp</Authors>
+    <Description>Configure async code's ConfigureAwait at a global level.</Description>
     <PackageOutputPath>$(SolutionDir)nugets</PackageOutputPath>
     <PackageIconUrl>https://raw.githubusercontent.com/Fody/ConfigureAwait/master/package_icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Fody/ConfigureAwait</PackageProjectUrl>


### PR DESCRIPTION
Adds a package description to `ConfigureAwait.csproj` (taken from the README tagline)

before:
![image](https://user-images.githubusercontent.com/7112040/79950284-75f33a00-843c-11ea-95d6-b86ee052350d.png)
after: 
![image](https://user-images.githubusercontent.com/7112040/79950297-7986c100-843c-11ea-91c1-3db8c981a710.png)

disclaimer: not a patron