### PR TITLE
Document DoNotWeave exceptions to manually-configured awaiters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ By default, `ConfigureAwait.Fody` doesn't change any code. Set a configure await
  * `[assembly: Fody.ConfigureAwait(false)]` - Assembly level
  * `[Fody.ConfigureAwait(false)]` - Class or method level
 
+Explicitly configured awaiters will not be overwritten by the weaver, allowing exceptions to the Assembly / Class / Method level setting.
 
 ### Add to FodyWeavers.xml
 
@@ -69,7 +70,7 @@ public class MyAsyncLibrary
     public async Task MyMethodAsync()
     {
         await Task.Delay(10);
-        await Task.Delay(20);
+        await Task.Delay(20).ConfigureAwait(true);
     }
 
     public async Task AnotherMethodAsync()
@@ -88,7 +89,7 @@ public class MyAsyncLibrary
     public async Task MyMethodAsync()
     {
         await Task.Delay(10).ConfigureAwait(false);
-        await Task.Delay(20).ConfigureAwait(false);
+        await Task.Delay(20).ConfigureAwait(true);
     }
 
     public async Task AnotherMethodAsync()


### PR DESCRIPTION
#### Description

The ability to "not weave" on explicit `ConfigureAwait(true)` (and other pre-configured awaiters?) appears to be implemented [and tested](../blob/master/AssemblyToProcess/DoNotWeave.cs), but is not documented or obvious from the ReadMe.

I think that if this were made obvious, it may bring more users to this plugin, especially with regards to codebases which require a few opt-in configured awaiters that run contrary to the general pattern in that assembly or class.

#### The solution

Documented that explicit `.ConfigureAwait(...)` calls are not rewoven. Existing example in the readme is altered to represent this fact.