### PR TITLE
Weave async iterator methods (#624, #597)

### DIFF
--- a/AssemblyToProcess/AsyncEnumerable.cs
+++ b/AssemblyToProcess/AsyncEnumerable.cs
@@ -1,0 +1,59 @@
+#if NET
+using Fody;
+
+[ConfigureAwait(false)]
+public class AsyncEnumerable
+{
+    // Issue #624: an async iterator method (lowered with AsyncIteratorStateMachineAttribute)
+    // must have its internal awaits configured. The only await here is the unconfigured
+    // Task.Delay, so the flag reflects whether the iterator body was woven.
+    public async IAsyncEnumerable<int> Producer(SynchronizationContext context)
+    {
+        SynchronizationContext.SetSynchronizationContext(context);
+        await Task.Delay(10);
+        yield return 1;
+        await Task.Delay(10);
+        yield return 2;
+    }
+
+    // Issue #597: consuming an IAsyncEnumerable<T> with `await foreach` awaits the
+    // ValueTask<bool>/ValueTask returned by MoveNextAsync/DisposeAsync. The source's own
+    // await is configured explicitly so only this consumer's awaits are under test.
+    public async Task AwaitForeach(SynchronizationContext context)
+    {
+        SynchronizationContext.SetSynchronizationContext(context);
+        // ReSharper disable once UnusedVariable
+        await foreach (var item in Source())
+        {
+        }
+    }
+
+    static async IAsyncEnumerable<int> Source()
+    {
+        await Task.Delay(10).ConfigureAwait(false);
+        yield return 1;
+    }
+
+    // Issue #597: consuming an IAsyncDisposable with `await using` awaits the ValueTask
+    // returned by DisposeAsync. The disposable's own await is configured explicitly so
+    // only this consumer's await is under test.
+    public async Task AwaitUsing(SynchronizationContext context)
+    {
+        SynchronizationContext.SetSynchronizationContext(context);
+        await using (new AsyncDisposable())
+        {
+        }
+    }
+}
+
+public class AsyncDisposable : IAsyncDisposable
+{
+    public async ValueTask DisposeAsync()
+    {
+        await Task.Delay(10).ConfigureAwait(false);
+        Disposed = true;
+    }
+
+    public static bool Disposed;
+}
+#endif

--- a/ConfigureAwait.Fody/AsyncStateMachineKind.cs
+++ b/ConfigureAwait.Fody/AsyncStateMachineKind.cs
@@ -1,0 +1,6 @@
+enum AsyncStateMachineKind
+{
+    None,
+    StateMachine,
+    CompilerService
+}

--- a/ConfigureAwait.Fody/AttributeCleaner.cs
+++ b/ConfigureAwait.Fody/AttributeCleaner.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Cecil;
-
-static class AttributeCleaner
+﻿static class AttributeCleaner
 {
     public static void Run(ModuleDefinition module)
     {

--- a/ConfigureAwait.Fody/CecilExtensions.cs
+++ b/ConfigureAwait.Fody/CecilExtensions.cs
@@ -49,9 +49,20 @@ static class CecilExtensions
         }
     }
 
+    // Async iterators (async IAsyncEnumerable<T> with yield) are lowered to a state machine
+    // just like normal async methods, but the generated method carries
+    // AsyncIteratorStateMachineAttribute rather than AsyncStateMachineAttribute.
+    static bool IsAsyncStateMachineAttribute(this CustomAttribute attribute)
+    {
+        var fullName = attribute.AttributeType.FullName;
+        return fullName is
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute" or
+            "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute";
+    }
+
     public static AsyncStateMachineKind GetAsyncStateMachineKind(this MethodDefinition method)
     {
-        if (method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute"))
+        if (method.CustomAttributes.Any(IsAsyncStateMachineAttribute))
             return AsyncStateMachineKind.StateMachine;
 
         if (method.ImplAttributes.HasFlag(MethodImplAttributes_Async))
@@ -63,7 +74,7 @@ static class CecilExtensions
     public static TypeDefinition GetAsyncStateMachineType(this ICustomAttributeProvider provider)
     {
         var attribute = provider.CustomAttributes
-            .FirstOrDefault(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute");
+            .FirstOrDefault(IsAsyncStateMachineAttribute);
 
         return (TypeDefinition)attribute?.ConstructorArguments[0].Value;
     }

--- a/ConfigureAwait.Fody/CecilExtensions.cs
+++ b/ConfigureAwait.Fody/CecilExtensions.cs
@@ -1,15 +1,4 @@
-﻿using Fody;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-
-enum AsyncStateMachineKind
-{
-    None,
-    StateMachine,
-    CompilerService
-}
-
-static class CecilExtensions
+﻿static class CecilExtensions
 {
     // Not yet defined in Cecil, remove later when update is available.
     const MethodImplAttributes MethodImplAttributes_Async = (MethodImplAttributes)0x2000;
@@ -22,7 +11,7 @@ static class CecilExtensions
         }
 
         return type.Interfaces
-            .Any(item => item.InterfaceType.FullName == "System.Runtime.CompilerServices.IAsyncStateMachine");
+            .Any(_ => _.InterfaceType.FullName == "System.Runtime.CompilerServices.IAsyncStateMachine");
     }
 
     public static MethodDefinition Method(this TypeDefinition type, MethodReference reference)
@@ -63,10 +52,14 @@ static class CecilExtensions
     public static AsyncStateMachineKind GetAsyncStateMachineKind(this MethodDefinition method)
     {
         if (method.CustomAttributes.Any(IsAsyncStateMachineAttribute))
+        {
             return AsyncStateMachineKind.StateMachine;
+        }
 
         if (method.ImplAttributes.HasFlag(MethodImplAttributes_Async))
+        {
             return AsyncStateMachineKind.CompilerService;
+        }
 
         return AsyncStateMachineKind.None;
     }

--- a/ConfigureAwait.Fody/GlobalUsings.cs
+++ b/ConfigureAwait.Fody/GlobalUsings.cs
@@ -1,0 +1,7 @@
+// Global using directives
+
+global using System.Xml;
+global using Fody;
+global using Mono.Cecil;
+global using Mono.Cecil.Cil;
+global using Mono.Cecil.Rocks;

--- a/ConfigureAwait.Fody/ModuleWeaver.cs
+++ b/ConfigureAwait.Fody/ModuleWeaver.cs
@@ -1,10 +1,4 @@
-﻿using System.Xml;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Rocks;
-using Fody;
-
-public partial class ModuleWeaver : BaseModuleWeaver
+﻿public partial class ModuleWeaver : BaseModuleWeaver
 {
     public override void Execute()
     {
@@ -181,7 +175,9 @@ public partial class ModuleWeaver : BaseModuleWeaver
             {
                 // Only redirect GetAwaiter; other members (including constructors) must not be redirected
                 if (method.Name != "GetAwaiter")
+                {
                     return;
+                }
 
                 var newOperand = genericConfiguredTaskAwaitableTypeDef.Method(method);
                 if (newOperand != null)
@@ -200,7 +196,9 @@ public partial class ModuleWeaver : BaseModuleWeaver
             {
                 // Only redirect GetAwaiter; other members (including constructors) must not be redirected
                 if (method.Name != "GetAwaiter")
+                {
                     return;
+                }
 
                 var newOperand = genericConfiguredValueTaskAwaitableTypeDef.Method(method);
                 if (newOperand != null)

--- a/ConfigureAwait.Fody/ModuleWeaver_CompilerServices.cs
+++ b/ConfigureAwait.Fody/ModuleWeaver_CompilerServices.cs
@@ -1,9 +1,4 @@
-﻿using Fody;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Rocks;
-
-public partial class ModuleWeaver
+﻿public partial class ModuleWeaver
 {
     /// <summary>
     /// Rewrites calls to <c>System.Runtime.CompilerServices.AsyncHelpers.Await(task)</c> inside
@@ -179,9 +174,10 @@ public partial class ModuleWeaver
 
     static MethodDefinition FindAwaitMethodDefinition(TypeDefinition declaringType, string configuredAwaitableName)
     {
-        return declaringType.Methods.FirstOrDefault(m =>
-            m.Name == "Await" &&
-            m.Parameters.Count == 1 &&
-            m.Parameters[0].ParameterType.Name == configuredAwaitableName) ?? throw new WeavingException($"Failed to find target method: Await({configuredAwaitableName})");
+        return declaringType.Methods
+            .FirstOrDefault(_ =>
+                _.Name == "Await" &&
+                _.Parameters.Count == 1 &&
+                _.Parameters[0].ParameterType.Name == configuredAwaitableName) ?? throw new WeavingException($"Failed to find target method: Await({configuredAwaitableName})");
     }
 }

--- a/ConfigureAwait.Fody/ModuleWeaver_Fields.cs
+++ b/ConfigureAwait.Fody/ModuleWeaver_Fields.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Cecil;
-
-public partial class ModuleWeaver
+﻿public partial class ModuleWeaver
 {
     void ProcessFields(TypeDefinition type)
     {

--- a/ConfigureAwait.Fody/ModuleWeaver_TypeFinder.cs
+++ b/ConfigureAwait.Fody/ModuleWeaver_TypeFinder.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Cecil;
-
-public partial class ModuleWeaver
+﻿public partial class ModuleWeaver
 {
     TypeReference configuredTaskAwaitableTypeRef;
     TypeReference configuredValueTaskAwaitableTypeRef;

--- a/ConfigureAwait.Fody/ModuleWeaver_Variables.cs
+++ b/ConfigureAwait.Fody/ModuleWeaver_Variables.cs
@@ -1,7 +1,4 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-
-public partial class ModuleWeaver
+﻿public partial class ModuleWeaver
 {
     void ProcessVariables(bool configureAwaitValue, MethodDefinition method)
     {

--- a/Tests/AsyncEnumerableTests.cs
+++ b/Tests/AsyncEnumerableTests.cs
@@ -1,0 +1,51 @@
+#if NET
+public partial class ModuleWeaverTests
+{
+    // Issue #624: the async iterator body must be woven so its awaits do not resume on
+    // the captured context.
+    [Fact]
+    public async Task AsyncEnumerable_Producer()
+    {
+        var context = testResult.GetInstance("FlagSynchronizationContext");
+        var test = testResult.GetInstance("AsyncEnumerable");
+
+        Assert.False(context.Flag);
+
+        var enumerable = (IAsyncEnumerable<int>)test.Producer(context);
+        // ReSharper disable once UnusedVariable
+        await foreach (var item in enumerable)
+        {
+        }
+
+        Assert.False(context.Flag);
+    }
+
+    // Issue #597: `await foreach` over an IAsyncEnumerable<T>.
+    [Fact]
+    public async Task AsyncEnumerable_AwaitForeach()
+    {
+        var context = testResult.GetInstance("FlagSynchronizationContext");
+        var test = testResult.GetInstance("AsyncEnumerable");
+
+        Assert.False(context.Flag);
+
+        await test.AwaitForeach(context);
+
+        Assert.False(context.Flag);
+    }
+
+    // Issue #597: `await using` over an IAsyncDisposable.
+    [Fact]
+    public async Task AsyncEnumerable_AwaitUsing()
+    {
+        var context = testResult.GetInstance("FlagSynchronizationContext");
+        var test = testResult.GetInstance("AsyncEnumerable");
+
+        Assert.False(context.Flag);
+
+        await test.AwaitUsing(context);
+
+        Assert.False(context.Flag);
+    }
+}
+#endif

--- a/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Debug.DotNet10_0.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Debug.DotNet10_0.verified.txt
@@ -1,0 +1,1461 @@
+﻿.class public auto ansi beforefieldinit AsyncEnumerable
+extends [System.Runtime]System.Object
+{
+.class auto ansi sealed nested private beforefieldinit '<AwaitForeach>d__1'
+extends [System.Runtime]System.Object
+implements [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Threading]System.Threading.SynchronizationContext context
+.field public class AsyncEnumerable '<>4__this'
+.field private class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> '<>s__1'
+.field private object '<>s__2'
+.field private int32 '<>s__3'
+.field private int32 '<item>5__4'
+.field private bool '<>s__5'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> '<>u__1'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__2'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Runtime]System.Threading.CancellationToken V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<bool> V_3,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_4,
+class AsyncEnumerable/'<AwaitForeach>d__1' V_5,
+object V_6,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_7,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_8,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_9,
+class [System.Runtime]System.Exception V_10)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0012
+IL_000a:  br.s       IL_000c
+IL_000c:  ldloc.0
+IL_000d:  ldc.i4.1
+IL_000e:  beq.s      IL_0014
+IL_0010:  br.s       IL_0019
+IL_0012:  br.s       IL_004e
+IL_0014:  br         IL_0156
+IL_0019:  nop
+IL_001a:  ldarg.0
+IL_001b:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitForeach>d__1'::context
+IL_0020:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0025:  nop
+IL_0026:  nop
+IL_0027:  ldarg.0
+IL_0028:  call       class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32> AsyncEnumerable::Source()
+IL_002d:  ldloca.s   V_1
+IL_002f:  initobj    [System.Runtime]System.Threading.CancellationToken
+IL_0035:  ldloc.1
+IL_0036:  callvirt   instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+IL_003b:  stfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__1'
+IL_0040:  ldarg.0
+IL_0041:  ldnull
+IL_0042:  stfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__2'
+IL_0047:  ldarg.0
+IL_0048:  ldc.i4.0
+IL_0049:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__3'
+IL_004e:  nop
+.try
+{
+IL_004f:  ldloc.0
+IL_0050:  brfalse.s  IL_0054
+IL_0052:  br.s       IL_0056
+IL_0054:  br.s       IL_00ba
+IL_0056:  br.s       IL_006b
+IL_0058:  ldarg.0
+IL_0059:  ldarg.0
+IL_005a:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__1'
+IL_005f:  callvirt   instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+IL_0064:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<item>5__4'
+IL_0069:  nop
+IL_006a:  nop
+IL_006b:  ldarg.0
+IL_006c:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__1'
+IL_0071:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+IL_0076:  stloc.s    V_4
+IL_0078:  ldloca.s   V_4
+IL_007a:  ldc.i4.0
+IL_007b:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<bool>::ConfigureAwait(bool)
+IL_0080:  stloc.3
+IL_0081:  ldloca.s   V_3
+IL_0083:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<bool>::GetAwaiter()
+IL_0088:  stloc.2
+IL_0089:  ldloca.s   V_2
+IL_008b:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>::get_IsCompleted()
+IL_0090:  brtrue.s   IL_00d6
+IL_0092:  ldarg.0
+IL_0093:  ldc.i4.0
+IL_0094:  dup
+IL_0095:  stloc.0
+IL_0096:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_009b:  ldarg.0
+IL_009c:  ldloc.2
+IL_009d:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__1'
+IL_00a2:  ldarg.0
+IL_00a3:  stloc.s    V_5
+IL_00a5:  ldarg.0
+IL_00a6:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_00ab:  ldloca.s   V_2
+IL_00ad:  ldloca.s   V_5
+IL_00af:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>,class AsyncEnumerable/'<AwaitForeach>d__1'>(!!0&,
+!!1&)
+IL_00b4:  nop
+IL_00b5:  leave      IL_01e9
+IL_00ba:  ldarg.0
+IL_00bb:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__1'
+IL_00c0:  stloc.2
+IL_00c1:  ldarg.0
+IL_00c2:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__1'
+IL_00c7:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>
+IL_00cd:  ldarg.0
+IL_00ce:  ldc.i4.m1
+IL_00cf:  dup
+IL_00d0:  stloc.0
+IL_00d1:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_00d6:  ldarg.0
+IL_00d7:  ldloca.s   V_2
+IL_00d9:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>::GetResult()
+IL_00de:  stfld      bool AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__5'
+IL_00e3:  ldarg.0
+IL_00e4:  ldfld      bool AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__5'
+IL_00e9:  brtrue     IL_0058
+IL_00ee:  leave.s    IL_00fc
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_00f0:  stloc.s    V_6
+IL_00f2:  ldarg.0
+IL_00f3:  ldloc.s    V_6
+IL_00f5:  stfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__2'
+IL_00fa:  leave.s    IL_00fc
+}  // end handler
+IL_00fc:  ldarg.0
+IL_00fd:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__1'
+IL_0102:  brfalse.s  IL_017b
+IL_0104:  ldarg.0
+IL_0105:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__1'
+IL_010a:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask [System.Runtime]System.IAsyncDisposable::DisposeAsync()
+IL_010f:  stloc.s    V_9
+IL_0111:  ldloca.s   V_9
+IL_0113:  ldc.i4.0
+IL_0114:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0119:  stloc.s    V_7
+IL_011b:  ldloca.s   V_7
+IL_011d:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0122:  stloc.s    V_8
+IL_0124:  ldloca.s   V_8
+IL_0126:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_012b:  brtrue.s   IL_0173
+IL_012d:  ldarg.0
+IL_012e:  ldc.i4.1
+IL_012f:  dup
+IL_0130:  stloc.0
+IL_0131:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0136:  ldarg.0
+IL_0137:  ldloc.s    V_8
+IL_0139:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__2'
+IL_013e:  ldarg.0
+IL_013f:  stloc.s    V_5
+IL_0141:  ldarg.0
+IL_0142:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0147:  ldloca.s   V_8
+IL_0149:  ldloca.s   V_5
+IL_014b:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AsyncEnumerable/'<AwaitForeach>d__1'>(!!0&,
+!!1&)
+IL_0150:  nop
+IL_0151:  leave      IL_01e9
+IL_0156:  ldarg.0
+IL_0157:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__2'
+IL_015c:  stloc.s    V_8
+IL_015e:  ldarg.0
+IL_015f:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__2'
+IL_0164:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_016a:  ldarg.0
+IL_016b:  ldc.i4.m1
+IL_016c:  dup
+IL_016d:  stloc.0
+IL_016e:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0173:  ldloca.s   V_8
+IL_0175:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_017a:  nop
+IL_017b:  ldarg.0
+IL_017c:  ldfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__2'
+IL_0181:  stloc.s    V_6
+IL_0183:  ldloc.s    V_6
+IL_0185:  brfalse.s  IL_01a4
+IL_0187:  ldloc.s    V_6
+IL_0189:  isinst     [System.Runtime]System.Exception
+IL_018e:  stloc.s    V_10
+IL_0190:  ldloc.s    V_10
+IL_0192:  brtrue.s   IL_0197
+IL_0194:  ldloc.s    V_6
+IL_0196:  throw
+IL_0197:  ldloc.s    V_10
+IL_0199:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_019e:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_01a3:  nop
+IL_01a4:  ldarg.0
+IL_01a5:  ldfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__3'
+IL_01aa:  pop
+IL_01ab:  ldarg.0
+IL_01ac:  ldnull
+IL_01ad:  stfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__2'
+IL_01b2:  ldarg.0
+IL_01b3:  ldnull
+IL_01b4:  stfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>s__1'
+IL_01b9:  leave.s    IL_01d5
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_01bb:  stloc.s    V_10
+IL_01bd:  ldarg.0
+IL_01be:  ldc.i4.s   -2
+IL_01c0:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_01c5:  ldarg.0
+IL_01c6:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_01cb:  ldloc.s    V_10
+IL_01cd:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_01d2:  nop
+IL_01d3:  leave.s    IL_01e9
+}  // end handler
+IL_01d5:  ldarg.0
+IL_01d6:  ldc.i4.s   -2
+IL_01d8:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_01dd:  ldarg.0
+IL_01de:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_01e3:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_01e8:  nop
+IL_01e9:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AwaitUsing>d__3'
+extends [System.Runtime]System.Object
+implements [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Threading]System.Threading.SynchronizationContext context
+.field public class AsyncEnumerable '<>4__this'
+.field private class AsyncDisposable '<>s__1'
+.field private object '<>s__2'
+.field private int32 '<>s__3'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+object V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_3,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_4,
+class AsyncEnumerable/'<AwaitUsing>d__3' V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_000c
+IL_000a:  br.s       IL_0011
+IL_000c:  br         IL_009c
+IL_0011:  nop
+IL_0012:  ldarg.0
+IL_0013:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitUsing>d__3'::context
+IL_0018:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_001d:  nop
+IL_001e:  ldarg.0
+IL_001f:  newobj     instance void AsyncDisposable::.ctor()
+IL_0024:  stfld      class AsyncDisposable AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__1'
+IL_0029:  ldarg.0
+IL_002a:  ldnull
+IL_002b:  stfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__2'
+IL_0030:  ldarg.0
+IL_0031:  ldc.i4.0
+IL_0032:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__3'
+.try
+{
+IL_0037:  nop
+IL_0038:  nop
+IL_0039:  leave.s    IL_0045
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_003b:  stloc.1
+IL_003c:  ldarg.0
+IL_003d:  ldloc.1
+IL_003e:  stfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__2'
+IL_0043:  leave.s    IL_0045
+}  // end handler
+IL_0045:  ldarg.0
+IL_0046:  ldfld      class AsyncDisposable AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__1'
+IL_004b:  brfalse.s  IL_00c0
+IL_004d:  ldarg.0
+IL_004e:  ldfld      class AsyncDisposable AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__1'
+IL_0053:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask AsyncDisposable::DisposeAsync()
+IL_0058:  stloc.s    V_4
+IL_005a:  ldloca.s   V_4
+IL_005c:  ldc.i4.0
+IL_005d:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0062:  stloc.3
+IL_0063:  ldloca.s   V_3
+IL_0065:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_006a:  stloc.2
+IL_006b:  ldloca.s   V_2
+IL_006d:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0072:  brtrue.s   IL_00b8
+IL_0074:  ldarg.0
+IL_0075:  ldc.i4.0
+IL_0076:  dup
+IL_0077:  stloc.0
+IL_0078:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_007d:  ldarg.0
+IL_007e:  ldloc.2
+IL_007f:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitUsing>d__3'::'<>u__1'
+IL_0084:  ldarg.0
+IL_0085:  stloc.s    V_5
+IL_0087:  ldarg.0
+IL_0088:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_008d:  ldloca.s   V_2
+IL_008f:  ldloca.s   V_5
+IL_0091:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,class AsyncEnumerable/'<AwaitUsing>d__3'>(!!0&,
+!!1&)
+IL_0096:  nop
+IL_0097:  leave      IL_012a
+IL_009c:  ldarg.0
+IL_009d:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitUsing>d__3'::'<>u__1'
+IL_00a2:  stloc.2
+IL_00a3:  ldarg.0
+IL_00a4:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitUsing>d__3'::'<>u__1'
+IL_00a9:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_00af:  ldarg.0
+IL_00b0:  ldc.i4.m1
+IL_00b1:  dup
+IL_00b2:  stloc.0
+IL_00b3:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_00b8:  ldloca.s   V_2
+IL_00ba:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_00bf:  nop
+IL_00c0:  ldarg.0
+IL_00c1:  ldfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__2'
+IL_00c6:  stloc.1
+IL_00c7:  ldloc.1
+IL_00c8:  brfalse.s  IL_00e5
+IL_00ca:  ldloc.1
+IL_00cb:  isinst     [System.Runtime]System.Exception
+IL_00d0:  stloc.s    V_6
+IL_00d2:  ldloc.s    V_6
+IL_00d4:  brtrue.s   IL_00d8
+IL_00d6:  ldloc.1
+IL_00d7:  throw
+IL_00d8:  ldloc.s    V_6
+IL_00da:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00df:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00e4:  nop
+IL_00e5:  ldarg.0
+IL_00e6:  ldfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__3'
+IL_00eb:  pop
+IL_00ec:  ldarg.0
+IL_00ed:  ldnull
+IL_00ee:  stfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__2'
+IL_00f3:  ldarg.0
+IL_00f4:  ldnull
+IL_00f5:  stfld      class AsyncDisposable AsyncEnumerable/'<AwaitUsing>d__3'::'<>s__1'
+IL_00fa:  leave.s    IL_0116
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00fc:  stloc.s    V_6
+IL_00fe:  ldarg.0
+IL_00ff:  ldc.i4.s   -2
+IL_0101:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_0106:  ldarg.0
+IL_0107:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_010c:  ldloc.s    V_6
+IL_010e:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0113:  nop
+IL_0114:  leave.s    IL_012a
+}  // end handler
+IL_0116:  ldarg.0
+IL_0117:  ldc.i4.s   -2
+IL_0119:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_011e:  ldarg.0
+IL_011f:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0124:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_0129:  nop
+IL_012a:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Producer>d__0'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private class [System.Threading]System.Threading.SynchronizationContext context
+.field public class [System.Threading]System.Threading.SynchronizationContext '<>3__context'
+.field public class AsyncEnumerable '<>4__this'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ldarg.0
+IL_0008:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000d:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0012:  ldarg.0
+IL_0013:  ldarg.1
+IL_0014:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0019:  ldarg.0
+IL_001a:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001f:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0024:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Producer>d__0' V_3,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_4,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -5
+IL_000a:  sub
+IL_000b:  switch     (
+IL_002e,
+IL_0033,
+IL_0038,
+IL_0041,
+IL_0041,
+IL_003a,
+IL_003c)
+IL_002c:  br.s       IL_0041
+IL_002e:  br         IL_017b
+IL_0033:  br         IL_00e4
+IL_0038:  br.s       IL_0041
+IL_003a:  br.s       IL_00aa
+IL_003c:  br         IL_0143
+IL_0041:  ldarg.0
+IL_0042:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0047:  brfalse.s  IL_004e
+IL_0049:  leave      IL_01bd
+IL_004e:  ldarg.0
+IL_004f:  ldc.i4.m1
+IL_0050:  dup
+IL_0051:  stloc.0
+IL_0052:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0057:  nop
+IL_0058:  ldarg.0
+IL_0059:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_005e:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0063:  nop
+IL_0064:  ldc.i4.s   10
+IL_0066:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_006b:  ldc.i4.0
+IL_006c:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0071:  stloc.2
+IL_0072:  ldloca.s   V_2
+IL_0074:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0079:  stloc.1
+IL_007a:  ldloca.s   V_1
+IL_007c:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0081:  brtrue.s   IL_00c6
+IL_0083:  ldarg.0
+IL_0084:  ldc.i4.0
+IL_0085:  dup
+IL_0086:  stloc.0
+IL_0087:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_008c:  ldarg.0
+IL_008d:  ldloc.1
+IL_008e:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0093:  ldarg.0
+IL_0094:  stloc.3
+IL_0095:  ldarg.0
+IL_0096:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_009b:  ldloca.s   V_1
+IL_009d:  ldloca.s   V_3
+IL_009f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_00a4:  nop
+IL_00a5:  leave      IL_01f3
+IL_00aa:  ldarg.0
+IL_00ab:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_00b0:  stloc.1
+IL_00b1:  ldarg.0
+IL_00b2:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_00b7:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_00bd:  ldarg.0
+IL_00be:  ldc.i4.m1
+IL_00bf:  dup
+IL_00c0:  stloc.0
+IL_00c1:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00c6:  ldloca.s   V_1
+IL_00c8:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00cd:  nop
+IL_00ce:  ldarg.0
+IL_00cf:  ldc.i4.1
+IL_00d0:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_00d5:  ldarg.0
+IL_00d6:  ldc.i4.s   -4
+IL_00d8:  dup
+IL_00d9:  stloc.0
+IL_00da:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00df:  leave      IL_01e6
+IL_00e4:  ldarg.0
+IL_00e5:  ldc.i4.m1
+IL_00e6:  dup
+IL_00e7:  stloc.0
+IL_00e8:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00ed:  ldarg.0
+IL_00ee:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_00f3:  brfalse.s  IL_00fa
+IL_00f5:  leave      IL_01bd
+IL_00fa:  ldc.i4.s   10
+IL_00fc:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0101:  ldc.i4.0
+IL_0102:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0107:  stloc.s    V_4
+IL_0109:  ldloca.s   V_4
+IL_010b:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0110:  stloc.s    V_5
+IL_0112:  ldloca.s   V_5
+IL_0114:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0119:  brtrue.s   IL_0160
+IL_011b:  ldarg.0
+IL_011c:  ldc.i4.1
+IL_011d:  dup
+IL_011e:  stloc.0
+IL_011f:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0124:  ldarg.0
+IL_0125:  ldloc.s    V_5
+IL_0127:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_012c:  ldarg.0
+IL_012d:  stloc.3
+IL_012e:  ldarg.0
+IL_012f:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0134:  ldloca.s   V_5
+IL_0136:  ldloca.s   V_3
+IL_0138:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_013d:  nop
+IL_013e:  leave      IL_01f3
+IL_0143:  ldarg.0
+IL_0144:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0149:  stloc.s    V_5
+IL_014b:  ldarg.0
+IL_014c:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0151:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0157:  ldarg.0
+IL_0158:  ldc.i4.m1
+IL_0159:  dup
+IL_015a:  stloc.0
+IL_015b:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0160:  ldloca.s   V_5
+IL_0162:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_0167:  nop
+IL_0168:  ldarg.0
+IL_0169:  ldc.i4.2
+IL_016a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_016f:  ldarg.0
+IL_0170:  ldc.i4.s   -5
+IL_0172:  dup
+IL_0173:  stloc.0
+IL_0174:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0179:  leave.s    IL_01e6
+IL_017b:  ldarg.0
+IL_017c:  ldc.i4.m1
+IL_017d:  dup
+IL_017e:  stloc.0
+IL_017f:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0184:  ldarg.0
+IL_0185:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_018a:  brfalse.s  IL_018e
+IL_018c:  leave.s    IL_01bd
+IL_018e:  leave.s    IL_01bd
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0190:  stloc.s    V_6
+IL_0192:  ldarg.0
+IL_0193:  ldc.i4.s   -2
+IL_0195:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_019a:  ldarg.0
+IL_019b:  ldc.i4.0
+IL_019c:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_01a1:  ldarg.0
+IL_01a2:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_01a7:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_01ac:  nop
+IL_01ad:  ldarg.0
+IL_01ae:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01b3:  ldloc.s    V_6
+IL_01b5:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_01ba:  nop
+IL_01bb:  leave.s    IL_01f3
+}  // end handler
+IL_01bd:  ldarg.0
+IL_01be:  ldc.i4.s   -2
+IL_01c0:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_01c5:  ldarg.0
+IL_01c6:  ldc.i4.0
+IL_01c7:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_01cc:  ldarg.0
+IL_01cd:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_01d2:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_01d7:  nop
+IL_01d8:  ldarg.0
+IL_01d9:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01de:  ldc.i4.0
+IL_01df:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01e4:  nop
+IL_01e5:  ret
+IL_01e6:  ldarg.0
+IL_01e7:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01ec:  ldc.i4.1
+IL_01ed:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01f2:  nop
+IL_01f3:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_0049
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ldarg.0
+IL_003f:  ldfld      class AsyncEnumerable AsyncEnumerable/'<Producer>d__0'::'<>4__this'
+IL_0044:  stfld      class AsyncEnumerable AsyncEnumerable/'<Producer>d__0'::'<>4__this'
+IL_0049:  ldloc.0
+IL_004a:  ldarg.0
+IL_004b:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_0050:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_0055:  ldloc.0
+IL_0056:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Producer>d__0'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Source>d__2'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ldarg.0
+IL_0008:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000d:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0012:  ldarg.0
+IL_0013:  ldarg.1
+IL_0014:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0019:  ldarg.0
+IL_001a:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001f:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0024:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Source>d__2' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -4
+IL_000a:  sub
+IL_000b:  switch     (
+IL_0026,
+IL_002b,
+IL_002f,
+IL_002f,
+IL_002d)
+IL_0024:  br.s       IL_002f
+IL_0026:  br         IL_00c3
+IL_002b:  br.s       IL_002f
+IL_002d:  br.s       IL_008c
+IL_002f:  ldarg.0
+IL_0030:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_0035:  brfalse.s  IL_003c
+IL_0037:  leave      IL_0105
+IL_003c:  ldarg.0
+IL_003d:  ldc.i4.m1
+IL_003e:  dup
+IL_003f:  stloc.0
+IL_0040:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0045:  nop
+IL_0046:  ldc.i4.s   10
+IL_0048:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_004d:  ldc.i4.0
+IL_004e:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Runtime]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0053:  stloc.2
+IL_0054:  ldloca.s   V_2
+IL_0056:  call       instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_005b:  stloc.1
+IL_005c:  ldloca.s   V_1
+IL_005e:  call       instance bool [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0063:  brtrue.s   IL_00a8
+IL_0065:  ldarg.0
+IL_0066:  ldc.i4.0
+IL_0067:  dup
+IL_0068:  stloc.0
+IL_0069:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_006e:  ldarg.0
+IL_006f:  ldloc.1
+IL_0070:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0075:  ldarg.0
+IL_0076:  stloc.3
+IL_0077:  ldarg.0
+IL_0078:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_007d:  ldloca.s   V_1
+IL_007f:  ldloca.s   V_3
+IL_0081:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Source>d__2'>(!!0&,
+!!1&)
+IL_0086:  nop
+IL_0087:  leave      IL_013b
+IL_008c:  ldarg.0
+IL_008d:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0092:  stloc.1
+IL_0093:  ldarg.0
+IL_0094:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0099:  initobj    [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_009f:  ldarg.0
+IL_00a0:  ldc.i4.m1
+IL_00a1:  dup
+IL_00a2:  stloc.0
+IL_00a3:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00a8:  ldloca.s   V_1
+IL_00aa:  call       instance void [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00af:  nop
+IL_00b0:  ldarg.0
+IL_00b1:  ldc.i4.1
+IL_00b2:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00b7:  ldarg.0
+IL_00b8:  ldc.i4.s   -4
+IL_00ba:  dup
+IL_00bb:  stloc.0
+IL_00bc:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00c1:  leave.s    IL_012e
+IL_00c3:  ldarg.0
+IL_00c4:  ldc.i4.m1
+IL_00c5:  dup
+IL_00c6:  stloc.0
+IL_00c7:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00cc:  ldarg.0
+IL_00cd:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_00d2:  brfalse.s  IL_00d6
+IL_00d4:  leave.s    IL_0105
+IL_00d6:  leave.s    IL_0105
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00d8:  stloc.s    V_4
+IL_00da:  ldarg.0
+IL_00db:  ldc.i4.s   -2
+IL_00dd:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00e2:  ldarg.0
+IL_00e3:  ldc.i4.0
+IL_00e4:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00e9:  ldarg.0
+IL_00ea:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_00ef:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_00f4:  nop
+IL_00f5:  ldarg.0
+IL_00f6:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_00fb:  ldloc.s    V_4
+IL_00fd:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_0102:  nop
+IL_0103:  leave.s    IL_013b
+}  // end handler
+IL_0105:  ldarg.0
+IL_0106:  ldc.i4.s   -2
+IL_0108:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_010d:  ldarg.0
+IL_010e:  ldc.i4.0
+IL_010f:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0114:  ldarg.0
+IL_0115:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_011a:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_011f:  nop
+IL_0120:  ldarg.0
+IL_0121:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0126:  ldc.i4.0
+IL_0127:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_012c:  nop
+IL_012d:  ret
+IL_012e:  ldarg.0
+IL_012f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0134:  ldc.i4.1
+IL_0135:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_013a:  nop
+IL_013b:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_003d
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Source>d__2'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.method public hidebysig instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Producer(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 50 72 6F 64 75 63 65 72 3E 64 5F 5F   // le+<Producer>d__
+30 00 00 )                                        // 0..
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_0007:  dup
+IL_0008:  ldarg.0
+IL_0009:  stfld      class AsyncEnumerable AsyncEnumerable/'<Producer>d__0'::'<>4__this'
+IL_000e:  dup
+IL_000f:  ldarg.1
+IL_0010:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_0015:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitForeach(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 41 77 61 69 74 46 6F 72 65 61 63 68   // le+<AwaitForeach
+3E 64 5F 5F 31 00 00 )                            // >d__1..
+.maxstack  2
+.locals init (class AsyncEnumerable/'<AwaitForeach>d__1' V_0)
+IL_0000:  newobj     instance void AsyncEnumerable/'<AwaitForeach>d__1'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_000c:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0011:  ldloc.0
+IL_0012:  ldarg.0
+IL_0013:  stfld      class AsyncEnumerable AsyncEnumerable/'<AwaitForeach>d__1'::'<>4__this'
+IL_0018:  ldloc.0
+IL_0019:  ldarg.1
+IL_001a:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitForeach>d__1'::context
+IL_001f:  ldloc.0
+IL_0020:  ldc.i4.m1
+IL_0021:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0026:  ldloc.0
+IL_0027:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_002c:  ldloca.s   V_0
+IL_002e:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AsyncEnumerable/'<AwaitForeach>d__1'>(!!0&)
+IL_0033:  ldloc.0
+IL_0034:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0039:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003e:  ret
+}
+.method private hidebysig static class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Source() cil managed
+{
+6C 65 2B 3C 53 6F 75 72 63 65 3E 64 5F 5F 32 00   // le+<Source>d__2.
+00 )
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_0007:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitUsing(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 41 77 61 69 74 55 73 69 6E 67 3E 64   // le+<AwaitUsing>d
+5F 5F 33 00 00 )                                  // __3..
+.maxstack  2
+.locals init (class AsyncEnumerable/'<AwaitUsing>d__3' V_0)
+IL_0000:  newobj     instance void AsyncEnumerable/'<AwaitUsing>d__3'::.ctor()
+IL_0005:  stloc.0
+IL_0006:  ldloc.0
+IL_0007:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_000c:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0011:  ldloc.0
+IL_0012:  ldarg.0
+IL_0013:  stfld      class AsyncEnumerable AsyncEnumerable/'<AwaitUsing>d__3'::'<>4__this'
+IL_0018:  ldloc.0
+IL_0019:  ldarg.1
+IL_001a:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitUsing>d__3'::context
+IL_001f:  ldloc.0
+IL_0020:  ldc.i4.m1
+IL_0021:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_0026:  ldloc.0
+IL_0027:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_002c:  ldloca.s   V_0
+IL_002e:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<class AsyncEnumerable/'<AwaitUsing>d__3'>(!!0&)
+IL_0033:  ldloc.0
+IL_0034:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0039:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_003e:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+}

--- a/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Debug.DotNet11_0.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Debug.DotNet11_0.verified.txt
@@ -1,0 +1,1102 @@
+﻿.class public auto ansi beforefieldinit AsyncEnumerable
+extends [System.Runtime]System.Object
+{
+.class auto ansi sealed nested private beforefieldinit '<Producer>d__0'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private class [System.Threading]System.Threading.SynchronizationContext context
+.field public class [System.Threading]System.Threading.SynchronizationContext '<>3__context'
+.field public class AsyncEnumerable '<>4__this'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ldarg.0
+IL_0008:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000d:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0012:  ldarg.0
+IL_0013:  ldarg.1
+IL_0014:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0019:  ldarg.0
+IL_001a:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001f:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0024:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Producer>d__0' V_3,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_4,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -5
+IL_000a:  sub
+IL_000b:  switch     (
+IL_002e,
+IL_0033,
+IL_0038,
+IL_0041,
+IL_0041,
+IL_003a,
+IL_003c)
+IL_002c:  br.s       IL_0041
+IL_002e:  br         IL_017b
+IL_0033:  br         IL_00e4
+IL_0038:  br.s       IL_0041
+IL_003a:  br.s       IL_00aa
+IL_003c:  br         IL_0143
+IL_0041:  ldarg.0
+IL_0042:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0047:  brfalse.s  IL_004e
+IL_0049:  leave      IL_01bd
+IL_004e:  ldarg.0
+IL_004f:  ldc.i4.m1
+IL_0050:  dup
+IL_0051:  stloc.0
+IL_0052:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0057:  nop
+IL_0058:  ldarg.0
+IL_0059:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_005e:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0063:  nop
+IL_0064:  ldc.i4.s   10
+IL_0066:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_006b:  ldc.i4.0
+IL_006c:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0071:  stloc.2
+IL_0072:  ldloca.s   V_2
+IL_0074:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0079:  stloc.1
+IL_007a:  ldloca.s   V_1
+IL_007c:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0081:  brtrue.s   IL_00c6
+IL_0083:  ldarg.0
+IL_0084:  ldc.i4.0
+IL_0085:  dup
+IL_0086:  stloc.0
+IL_0087:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_008c:  ldarg.0
+IL_008d:  ldloc.1
+IL_008e:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0093:  ldarg.0
+IL_0094:  stloc.3
+IL_0095:  ldarg.0
+IL_0096:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_009b:  ldloca.s   V_1
+IL_009d:  ldloca.s   V_3
+IL_009f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_00a4:  nop
+IL_00a5:  leave      IL_01f3
+IL_00aa:  ldarg.0
+IL_00ab:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_00b0:  stloc.1
+IL_00b1:  ldarg.0
+IL_00b2:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_00b7:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_00bd:  ldarg.0
+IL_00be:  ldc.i4.m1
+IL_00bf:  dup
+IL_00c0:  stloc.0
+IL_00c1:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00c6:  ldloca.s   V_1
+IL_00c8:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00cd:  nop
+IL_00ce:  ldarg.0
+IL_00cf:  ldc.i4.1
+IL_00d0:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_00d5:  ldarg.0
+IL_00d6:  ldc.i4.s   -4
+IL_00d8:  dup
+IL_00d9:  stloc.0
+IL_00da:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00df:  leave      IL_01e6
+IL_00e4:  ldarg.0
+IL_00e5:  ldc.i4.m1
+IL_00e6:  dup
+IL_00e7:  stloc.0
+IL_00e8:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00ed:  ldarg.0
+IL_00ee:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_00f3:  brfalse.s  IL_00fa
+IL_00f5:  leave      IL_01bd
+IL_00fa:  ldc.i4.s   10
+IL_00fc:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0101:  ldc.i4.0
+IL_0102:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0107:  stloc.s    V_4
+IL_0109:  ldloca.s   V_4
+IL_010b:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0110:  stloc.s    V_5
+IL_0112:  ldloca.s   V_5
+IL_0114:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0119:  brtrue.s   IL_0160
+IL_011b:  ldarg.0
+IL_011c:  ldc.i4.1
+IL_011d:  dup
+IL_011e:  stloc.0
+IL_011f:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0124:  ldarg.0
+IL_0125:  ldloc.s    V_5
+IL_0127:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_012c:  ldarg.0
+IL_012d:  stloc.3
+IL_012e:  ldarg.0
+IL_012f:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0134:  ldloca.s   V_5
+IL_0136:  ldloca.s   V_3
+IL_0138:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_013d:  nop
+IL_013e:  leave      IL_01f3
+IL_0143:  ldarg.0
+IL_0144:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0149:  stloc.s    V_5
+IL_014b:  ldarg.0
+IL_014c:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0151:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0157:  ldarg.0
+IL_0158:  ldc.i4.m1
+IL_0159:  dup
+IL_015a:  stloc.0
+IL_015b:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0160:  ldloca.s   V_5
+IL_0162:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_0167:  nop
+IL_0168:  ldarg.0
+IL_0169:  ldc.i4.2
+IL_016a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_016f:  ldarg.0
+IL_0170:  ldc.i4.s   -5
+IL_0172:  dup
+IL_0173:  stloc.0
+IL_0174:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0179:  leave.s    IL_01e6
+IL_017b:  ldarg.0
+IL_017c:  ldc.i4.m1
+IL_017d:  dup
+IL_017e:  stloc.0
+IL_017f:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0184:  ldarg.0
+IL_0185:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_018a:  brfalse.s  IL_018e
+IL_018c:  leave.s    IL_01bd
+IL_018e:  leave.s    IL_01bd
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0190:  stloc.s    V_6
+IL_0192:  ldarg.0
+IL_0193:  ldc.i4.s   -2
+IL_0195:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_019a:  ldarg.0
+IL_019b:  ldc.i4.0
+IL_019c:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_01a1:  ldarg.0
+IL_01a2:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_01a7:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_01ac:  nop
+IL_01ad:  ldarg.0
+IL_01ae:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01b3:  ldloc.s    V_6
+IL_01b5:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_01ba:  nop
+IL_01bb:  leave.s    IL_01f3
+}  // end handler
+IL_01bd:  ldarg.0
+IL_01be:  ldc.i4.s   -2
+IL_01c0:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_01c5:  ldarg.0
+IL_01c6:  ldc.i4.0
+IL_01c7:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_01cc:  ldarg.0
+IL_01cd:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_01d2:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_01d7:  nop
+IL_01d8:  ldarg.0
+IL_01d9:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01de:  ldc.i4.0
+IL_01df:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01e4:  nop
+IL_01e5:  ret
+IL_01e6:  ldarg.0
+IL_01e7:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01ec:  ldc.i4.1
+IL_01ed:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01f2:  nop
+IL_01f3:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_0049
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ldarg.0
+IL_003f:  ldfld      class AsyncEnumerable AsyncEnumerable/'<Producer>d__0'::'<>4__this'
+IL_0044:  stfld      class AsyncEnumerable AsyncEnumerable/'<Producer>d__0'::'<>4__this'
+IL_0049:  ldloc.0
+IL_004a:  ldarg.0
+IL_004b:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_0050:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_0055:  ldloc.0
+IL_0056:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Producer>d__0'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Source>d__2'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ldarg.0
+IL_0008:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000d:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0012:  ldarg.0
+IL_0013:  ldarg.1
+IL_0014:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0019:  ldarg.0
+IL_001a:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001f:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0024:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Source>d__2' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -4
+IL_000a:  sub
+IL_000b:  switch     (
+IL_0026,
+IL_002b,
+IL_002f,
+IL_002f,
+IL_002d)
+IL_0024:  br.s       IL_002f
+IL_0026:  br         IL_00c3
+IL_002b:  br.s       IL_002f
+IL_002d:  br.s       IL_008c
+IL_002f:  ldarg.0
+IL_0030:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_0035:  brfalse.s  IL_003c
+IL_0037:  leave      IL_0105
+IL_003c:  ldarg.0
+IL_003d:  ldc.i4.m1
+IL_003e:  dup
+IL_003f:  stloc.0
+IL_0040:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0045:  nop
+IL_0046:  ldc.i4.s   10
+IL_0048:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_004d:  ldc.i4.0
+IL_004e:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Runtime]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0053:  stloc.2
+IL_0054:  ldloca.s   V_2
+IL_0056:  call       instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_005b:  stloc.1
+IL_005c:  ldloca.s   V_1
+IL_005e:  call       instance bool [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0063:  brtrue.s   IL_00a8
+IL_0065:  ldarg.0
+IL_0066:  ldc.i4.0
+IL_0067:  dup
+IL_0068:  stloc.0
+IL_0069:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_006e:  ldarg.0
+IL_006f:  ldloc.1
+IL_0070:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0075:  ldarg.0
+IL_0076:  stloc.3
+IL_0077:  ldarg.0
+IL_0078:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_007d:  ldloca.s   V_1
+IL_007f:  ldloca.s   V_3
+IL_0081:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Source>d__2'>(!!0&,
+!!1&)
+IL_0086:  nop
+IL_0087:  leave      IL_013b
+IL_008c:  ldarg.0
+IL_008d:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0092:  stloc.1
+IL_0093:  ldarg.0
+IL_0094:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0099:  initobj    [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_009f:  ldarg.0
+IL_00a0:  ldc.i4.m1
+IL_00a1:  dup
+IL_00a2:  stloc.0
+IL_00a3:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00a8:  ldloca.s   V_1
+IL_00aa:  call       instance void [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00af:  nop
+IL_00b0:  ldarg.0
+IL_00b1:  ldc.i4.1
+IL_00b2:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00b7:  ldarg.0
+IL_00b8:  ldc.i4.s   -4
+IL_00ba:  dup
+IL_00bb:  stloc.0
+IL_00bc:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00c1:  leave.s    IL_012e
+IL_00c3:  ldarg.0
+IL_00c4:  ldc.i4.m1
+IL_00c5:  dup
+IL_00c6:  stloc.0
+IL_00c7:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00cc:  ldarg.0
+IL_00cd:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_00d2:  brfalse.s  IL_00d6
+IL_00d4:  leave.s    IL_0105
+IL_00d6:  leave.s    IL_0105
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00d8:  stloc.s    V_4
+IL_00da:  ldarg.0
+IL_00db:  ldc.i4.s   -2
+IL_00dd:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00e2:  ldarg.0
+IL_00e3:  ldc.i4.0
+IL_00e4:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00e9:  ldarg.0
+IL_00ea:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_00ef:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_00f4:  nop
+IL_00f5:  ldarg.0
+IL_00f6:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_00fb:  ldloc.s    V_4
+IL_00fd:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_0102:  nop
+IL_0103:  leave.s    IL_013b
+}  // end handler
+IL_0105:  ldarg.0
+IL_0106:  ldc.i4.s   -2
+IL_0108:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_010d:  ldarg.0
+IL_010e:  ldc.i4.0
+IL_010f:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0114:  ldarg.0
+IL_0115:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_011a:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_011f:  nop
+IL_0120:  ldarg.0
+IL_0121:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0126:  ldc.i4.0
+IL_0127:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_012c:  nop
+IL_012d:  ret
+IL_012e:  ldarg.0
+IL_012f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0134:  ldc.i4.1
+IL_0135:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_013a:  nop
+IL_013b:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_003d
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Source>d__2'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.method public hidebysig instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Producer(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 50 72 6F 64 75 63 65 72 3E 64 5F 5F   // le+<Producer>d__
+30 00 00 )                                        // 0..
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_0007:  dup
+IL_0008:  ldarg.0
+IL_0009:  stfld      class AsyncEnumerable AsyncEnumerable/'<Producer>d__0'::'<>4__this'
+IL_000e:  dup
+IL_000f:  ldarg.1
+IL_0010:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_0015:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitForeach(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+.maxstack  2
+.locals init (class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> V_0,
+valuetype [System.Runtime]System.Threading.CancellationToken V_1,
+object V_2,
+int32 V_3,
+int32 V_4,
+bool V_5,
+class [System.Runtime]System.Exception V_6,
+valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<bool> V_7,
+valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask V_8)
+IL_0000:  nop
+IL_0001:  ldarg.1
+IL_0002:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0007:  nop
+IL_0008:  nop
+IL_0009:  call       class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32> AsyncEnumerable::Source()
+IL_000e:  ldloca.s   V_1
+IL_0010:  initobj    [System.Runtime]System.Threading.CancellationToken
+IL_0016:  ldloc.1
+IL_0017:  callvirt   instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+IL_001c:  stloc.0
+IL_001d:  ldnull
+IL_001e:  stloc.2
+IL_001f:  ldc.i4.0
+IL_0020:  stloc.3
+.try
+{
+IL_0021:  br.s       IL_002d
+IL_0023:  ldloc.0
+IL_0024:  callvirt   instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+IL_0029:  stloc.s    V_4
+IL_002b:  nop
+IL_002c:  nop
+IL_002d:  ldloc.0
+IL_002e:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+IL_0033:  stloc.s    V_7
+IL_0035:  ldloca.s   V_7
+IL_0037:  ldc.i4.0
+IL_0038:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<bool>::ConfigureAwait(bool)
+IL_003d:  call       !!0 [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await<bool>(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!!0>)
+IL_0042:  stloc.s    V_5
+IL_0044:  ldloc.s    V_5
+IL_0046:  brtrue.s   IL_0023
+IL_0048:  leave.s    IL_004d
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_004a:  stloc.2
+IL_004b:  leave.s    IL_004d
+}  // end handler
+IL_004d:  ldloc.0
+IL_004e:  brfalse.s  IL_0066
+IL_0050:  ldloc.0
+IL_0051:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask [System.Runtime]System.IAsyncDisposable::DisposeAsync()
+IL_0056:  stloc.s    V_8
+IL_0058:  ldloca.s   V_8
+IL_005a:  ldc.i4.0
+IL_005b:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0060:  call       void [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable)
+IL_0065:  nop
+IL_0066:  ldloc.2
+IL_0067:  brfalse.s  IL_0084
+IL_0069:  ldloc.2
+IL_006a:  isinst     [System.Runtime]System.Exception
+IL_006f:  stloc.s    V_6
+IL_0071:  ldloc.s    V_6
+IL_0073:  brtrue.s   IL_0077
+IL_0075:  ldloc.2
+IL_0076:  throw
+IL_0077:  ldloc.s    V_6
+IL_0079:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_007e:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_0083:  nop
+IL_0084:  ret
+}
+.method private hidebysig static class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Source() cil managed
+{
+6C 65 2B 3C 53 6F 75 72 63 65 3E 64 5F 5F 32 00   // le+<Source>d__2.
+00 )
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_0007:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitUsing(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+.maxstack  2
+.locals init (class AsyncDisposable V_0,
+object V_1,
+int32 V_2,
+class [System.Runtime]System.Exception V_3,
+valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask V_4)
+IL_0000:  nop
+IL_0001:  ldarg.1
+IL_0002:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0007:  nop
+IL_0008:  newobj     instance void AsyncDisposable::.ctor()
+IL_000d:  stloc.0
+IL_000e:  ldnull
+IL_000f:  stloc.1
+IL_0010:  ldc.i4.0
+IL_0011:  stloc.2
+.try
+{
+IL_0012:  nop
+IL_0013:  nop
+IL_0014:  leave.s    IL_0019
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0016:  stloc.1
+IL_0017:  leave.s    IL_0019
+}  // end handler
+IL_0019:  ldloc.0
+IL_001a:  brfalse.s  IL_0032
+IL_001c:  ldloc.0
+IL_001d:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask AsyncDisposable::DisposeAsync()
+IL_0022:  stloc.s    V_4
+IL_0024:  ldloca.s   V_4
+IL_0026:  ldc.i4.0
+IL_0027:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_002c:  call       void [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable)
+IL_0031:  nop
+IL_0032:  ldloc.1
+IL_0033:  brfalse.s  IL_004d
+IL_0035:  ldloc.1
+IL_0036:  isinst     [System.Runtime]System.Exception
+IL_003b:  stloc.3
+IL_003c:  ldloc.3
+IL_003d:  brtrue.s   IL_0041
+IL_003f:  ldloc.1
+IL_0040:  throw
+IL_0041:  ldloc.3
+IL_0042:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_0047:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_004c:  nop
+IL_004d:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  nop
+IL_0007:  ret
+}
+}

--- a/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Release.DotNet10_0.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Release.DotNet10_0.verified.txt
@@ -1,0 +1,1336 @@
+﻿.class public auto ansi beforefieldinit AsyncEnumerable
+extends [System.Runtime]System.Object
+{
+.class auto ansi sealed nested private beforefieldinit '<AwaitForeach>d__1'
+extends [System.Runtime]System.ValueType
+implements [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Threading]System.Threading.SynchronizationContext context
+.field private class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> '<>7__wrap1'
+.field private object '<>7__wrap2'
+.field private int32 '<>7__wrap3'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> '<>u__1'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__2'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Runtime]System.Threading.CancellationToken V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<bool> V_3,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_4,
+object V_5,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_6,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_7,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_8,
+class [System.Runtime]System.Exception V_9)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0043
+IL_000a:  ldloc.0
+IL_000b:  ldc.i4.1
+IL_000c:  beq        IL_0127
+IL_0011:  ldarg.0
+IL_0012:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitForeach>d__1'::context
+IL_0017:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_001c:  ldarg.0
+IL_001d:  call       class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32> AsyncEnumerable::Source()
+IL_0022:  ldloca.s   V_1
+IL_0024:  initobj    [System.Runtime]System.Threading.CancellationToken
+IL_002a:  ldloc.1
+IL_002b:  callvirt   instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+IL_0030:  stfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap1'
+IL_0035:  ldarg.0
+IL_0036:  ldnull
+IL_0037:  stfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap2'
+IL_003c:  ldarg.0
+IL_003d:  ldc.i4.0
+IL_003e:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap3'
+IL_0043:  nop
+.try
+{
+IL_0044:  ldloc.0
+IL_0045:  brfalse.s  IL_009f
+IL_0047:  br.s       IL_0055
+IL_0049:  ldarg.0
+IL_004a:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap1'
+IL_004f:  callvirt   instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+IL_0054:  pop
+IL_0055:  ldarg.0
+IL_0056:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap1'
+IL_005b:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+IL_0060:  stloc.s    V_4
+IL_0062:  ldloca.s   V_4
+IL_0064:  ldc.i4.0
+IL_0065:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<bool>::ConfigureAwait(bool)
+IL_006a:  stloc.3
+IL_006b:  ldloca.s   V_3
+IL_006d:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<!0> valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<bool>::GetAwaiter()
+IL_0072:  stloc.2
+IL_0073:  ldloca.s   V_2
+IL_0075:  call       instance bool valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>::get_IsCompleted()
+IL_007a:  brtrue.s   IL_00bb
+IL_007c:  ldarg.0
+IL_007d:  ldc.i4.0
+IL_007e:  dup
+IL_007f:  stloc.0
+IL_0080:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0085:  ldarg.0
+IL_0086:  ldloc.2
+IL_0087:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__1'
+IL_008c:  ldarg.0
+IL_008d:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0092:  ldloca.s   V_2
+IL_0094:  ldarg.0
+IL_0095:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>,valuetype AsyncEnumerable/'<AwaitForeach>d__1'>(!!0&,
+!!1&)
+IL_009a:  leave      IL_01aa
+IL_009f:  ldarg.0
+IL_00a0:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__1'
+IL_00a5:  stloc.2
+IL_00a6:  ldarg.0
+IL_00a7:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool> AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__1'
+IL_00ac:  initobj    valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>
+IL_00b2:  ldarg.0
+IL_00b3:  ldc.i4.m1
+IL_00b4:  dup
+IL_00b5:  stloc.0
+IL_00b6:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_00bb:  ldloca.s   V_2
+IL_00bd:  call       instance !0 valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter<bool>::GetResult()
+IL_00c2:  brtrue.s   IL_0049
+IL_00c4:  leave.s    IL_00d2
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_00c6:  stloc.s    V_5
+IL_00c8:  ldarg.0
+IL_00c9:  ldloc.s    V_5
+IL_00cb:  stfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap2'
+IL_00d0:  leave.s    IL_00d2
+}  // end handler
+IL_00d2:  ldarg.0
+IL_00d3:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap1'
+IL_00d8:  brfalse.s  IL_014b
+IL_00da:  ldarg.0
+IL_00db:  ldfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap1'
+IL_00e0:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask [System.Runtime]System.IAsyncDisposable::DisposeAsync()
+IL_00e5:  stloc.s    V_8
+IL_00e7:  ldloca.s   V_8
+IL_00e9:  ldc.i4.0
+IL_00ea:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_00ef:  stloc.s    V_6
+IL_00f1:  ldloca.s   V_6
+IL_00f3:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_00f8:  stloc.s    V_7
+IL_00fa:  ldloca.s   V_7
+IL_00fc:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_0101:  brtrue.s   IL_0144
+IL_0103:  ldarg.0
+IL_0104:  ldc.i4.1
+IL_0105:  dup
+IL_0106:  stloc.0
+IL_0107:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_010c:  ldarg.0
+IL_010d:  ldloc.s    V_7
+IL_010f:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__2'
+IL_0114:  ldarg.0
+IL_0115:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_011a:  ldloca.s   V_7
+IL_011c:  ldarg.0
+IL_011d:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AsyncEnumerable/'<AwaitForeach>d__1'>(!!0&,
+!!1&)
+IL_0122:  leave      IL_01aa
+IL_0127:  ldarg.0
+IL_0128:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__2'
+IL_012d:  stloc.s    V_7
+IL_012f:  ldarg.0
+IL_0130:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitForeach>d__1'::'<>u__2'
+IL_0135:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_013b:  ldarg.0
+IL_013c:  ldc.i4.m1
+IL_013d:  dup
+IL_013e:  stloc.0
+IL_013f:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0144:  ldloca.s   V_7
+IL_0146:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_014b:  ldarg.0
+IL_014c:  ldfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap2'
+IL_0151:  stloc.s    V_5
+IL_0153:  ldloc.s    V_5
+IL_0155:  brfalse.s  IL_016e
+IL_0157:  ldloc.s    V_5
+IL_0159:  isinst     [System.Runtime]System.Exception
+IL_015e:  dup
+IL_015f:  brtrue.s   IL_0164
+IL_0161:  ldloc.s    V_5
+IL_0163:  throw
+IL_0164:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_0169:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_016e:  ldarg.0
+IL_016f:  ldnull
+IL_0170:  stfld      object AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap2'
+IL_0175:  ldarg.0
+IL_0176:  ldnull
+IL_0177:  stfld      class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> AsyncEnumerable/'<AwaitForeach>d__1'::'<>7__wrap1'
+IL_017c:  leave.s    IL_0197
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_017e:  stloc.s    V_9
+IL_0180:  ldarg.0
+IL_0181:  ldc.i4.s   -2
+IL_0183:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_0188:  ldarg.0
+IL_0189:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_018e:  ldloc.s    V_9
+IL_0190:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_0195:  leave.s    IL_01aa
+}  // end handler
+IL_0197:  ldarg.0
+IL_0198:  ldc.i4.s   -2
+IL_019a:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_019f:  ldarg.0
+IL_01a0:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_01a5:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_01aa:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<AwaitUsing>d__3'
+extends [System.Runtime]System.ValueType
+implements [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public class [System.Threading]System.Threading.SynchronizationContext context
+.field private object '<>7__wrap1'
+.field private int32 '<>7__wrap2'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+class AsyncDisposable V_1,
+object V_2,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter V_3,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable V_4,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_5,
+class [System.Runtime]System.Exception V_6)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse    IL_0081
+IL_000d:  ldarg.0
+IL_000e:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitUsing>d__3'::context
+IL_0013:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0018:  newobj     instance void AsyncDisposable::.ctor()
+IL_001d:  stloc.1
+IL_001e:  ldarg.0
+IL_001f:  ldnull
+IL_0020:  stfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>7__wrap1'
+IL_0025:  ldarg.0
+IL_0026:  ldc.i4.0
+IL_0027:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>7__wrap2'
+.try
+{
+IL_002c:  leave.s    IL_0038
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_002e:  stloc.2
+IL_002f:  ldarg.0
+IL_0030:  ldloc.2
+IL_0031:  stfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>7__wrap1'
+IL_0036:  leave.s    IL_0038
+}  // end handler
+IL_0038:  ldloc.1
+IL_0039:  brfalse.s  IL_00a4
+IL_003b:  ldloc.1
+IL_003c:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask AsyncDisposable::DisposeAsync()
+IL_0041:  stloc.s    V_5
+IL_0043:  ldloca.s   V_5
+IL_0045:  ldc.i4.0
+IL_0046:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_004b:  stloc.s    V_4
+IL_004d:  ldloca.s   V_4
+IL_004f:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable::GetAwaiter()
+IL_0054:  stloc.3
+IL_0055:  ldloca.s   V_3
+IL_0057:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::get_IsCompleted()
+IL_005c:  brtrue.s   IL_009d
+IL_005e:  ldarg.0
+IL_005f:  ldc.i4.0
+IL_0060:  dup
+IL_0061:  stloc.0
+IL_0062:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_0067:  ldarg.0
+IL_0068:  ldloc.3
+IL_0069:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitUsing>d__3'::'<>u__1'
+IL_006e:  ldarg.0
+IL_006f:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0074:  ldloca.s   V_3
+IL_0076:  ldarg.0
+IL_0077:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter,valuetype AsyncEnumerable/'<AwaitUsing>d__3'>(!!0&,
+!!1&)
+IL_007c:  leave      IL_00f8
+IL_0081:  ldarg.0
+IL_0082:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitUsing>d__3'::'<>u__1'
+IL_0087:  stloc.3
+IL_0088:  ldarg.0
+IL_0089:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter AsyncEnumerable/'<AwaitUsing>d__3'::'<>u__1'
+IL_008e:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter
+IL_0094:  ldarg.0
+IL_0095:  ldc.i4.m1
+IL_0096:  dup
+IL_0097:  stloc.0
+IL_0098:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_009d:  ldloca.s   V_3
+IL_009f:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable/ConfiguredValueTaskAwaiter::GetResult()
+IL_00a4:  ldarg.0
+IL_00a5:  ldfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>7__wrap1'
+IL_00aa:  stloc.2
+IL_00ab:  ldloc.2
+IL_00ac:  brfalse.s  IL_00c3
+IL_00ae:  ldloc.2
+IL_00af:  isinst     [System.Runtime]System.Exception
+IL_00b4:  dup
+IL_00b5:  brtrue.s   IL_00b9
+IL_00b7:  ldloc.2
+IL_00b8:  throw
+IL_00b9:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_00be:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_00c3:  ldarg.0
+IL_00c4:  ldnull
+IL_00c5:  stfld      object AsyncEnumerable/'<AwaitUsing>d__3'::'<>7__wrap1'
+IL_00ca:  leave.s    IL_00e5
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00cc:  stloc.s    V_6
+IL_00ce:  ldarg.0
+IL_00cf:  ldc.i4.s   -2
+IL_00d1:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_00d6:  ldarg.0
+IL_00d7:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_00dc:  ldloc.s    V_6
+IL_00de:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_00e3:  leave.s    IL_00f8
+}  // end handler
+IL_00e5:  ldarg.0
+IL_00e6:  ldc.i4.s   -2
+IL_00e8:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_00ed:  ldarg.0
+IL_00ee:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_00f3:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00f8:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Producer>d__0'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private class [System.Threading]System.Threading.SynchronizationContext context
+.field public class [System.Threading]System.Threading.SynchronizationContext '<>3__context'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ldarg.0
+IL_0007:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000c:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0011:  ldarg.0
+IL_0012:  ldarg.1
+IL_0013:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0018:  ldarg.0
+IL_0019:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001e:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0023:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Producer>d__0' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -5
+IL_000a:  sub
+IL_000b:  switch     (
+IL_015c,
+IL_00cb,
+IL_002c,
+IL_002c,
+IL_002c,
+IL_0092,
+IL_0126)
+IL_002c:  ldarg.0
+IL_002d:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0032:  brfalse.s  IL_0039
+IL_0034:  leave      IL_0199
+IL_0039:  ldarg.0
+IL_003a:  ldc.i4.m1
+IL_003b:  dup
+IL_003c:  stloc.0
+IL_003d:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0042:  ldarg.0
+IL_0043:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_0048:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_004d:  ldc.i4.s   10
+IL_004f:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0054:  ldc.i4.0
+IL_0055:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_005a:  stloc.2
+IL_005b:  ldloca.s   V_2
+IL_005d:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0062:  stloc.1
+IL_0063:  ldloca.s   V_1
+IL_0065:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_006a:  brtrue.s   IL_00ae
+IL_006c:  ldarg.0
+IL_006d:  ldc.i4.0
+IL_006e:  dup
+IL_006f:  stloc.0
+IL_0070:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0075:  ldarg.0
+IL_0076:  ldloc.1
+IL_0077:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_007c:  ldarg.0
+IL_007d:  stloc.3
+IL_007e:  ldarg.0
+IL_007f:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0084:  ldloca.s   V_1
+IL_0086:  ldloca.s   V_3
+IL_0088:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_008d:  leave      IL_01cc
+IL_0092:  ldarg.0
+IL_0093:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0098:  stloc.1
+IL_0099:  ldarg.0
+IL_009a:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_009f:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_00a5:  ldarg.0
+IL_00a6:  ldc.i4.m1
+IL_00a7:  dup
+IL_00a8:  stloc.0
+IL_00a9:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00ae:  ldloca.s   V_1
+IL_00b0:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00b5:  ldarg.0
+IL_00b6:  ldc.i4.1
+IL_00b7:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_00bc:  ldarg.0
+IL_00bd:  ldc.i4.s   -4
+IL_00bf:  dup
+IL_00c0:  stloc.0
+IL_00c1:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00c6:  leave      IL_01c0
+IL_00cb:  ldarg.0
+IL_00cc:  ldc.i4.m1
+IL_00cd:  dup
+IL_00ce:  stloc.0
+IL_00cf:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00d4:  ldarg.0
+IL_00d5:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_00da:  brfalse.s  IL_00e1
+IL_00dc:  leave      IL_0199
+IL_00e1:  ldc.i4.s   10
+IL_00e3:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00e8:  ldc.i4.0
+IL_00e9:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_00ee:  stloc.2
+IL_00ef:  ldloca.s   V_2
+IL_00f1:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_00f6:  stloc.1
+IL_00f7:  ldloca.s   V_1
+IL_00f9:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_00fe:  brtrue.s   IL_0142
+IL_0100:  ldarg.0
+IL_0101:  ldc.i4.1
+IL_0102:  dup
+IL_0103:  stloc.0
+IL_0104:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0109:  ldarg.0
+IL_010a:  ldloc.1
+IL_010b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0110:  ldarg.0
+IL_0111:  stloc.3
+IL_0112:  ldarg.0
+IL_0113:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0118:  ldloca.s   V_1
+IL_011a:  ldloca.s   V_3
+IL_011c:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_0121:  leave      IL_01cc
+IL_0126:  ldarg.0
+IL_0127:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_012c:  stloc.1
+IL_012d:  ldarg.0
+IL_012e:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0133:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0139:  ldarg.0
+IL_013a:  ldc.i4.m1
+IL_013b:  dup
+IL_013c:  stloc.0
+IL_013d:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0142:  ldloca.s   V_1
+IL_0144:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_0149:  ldarg.0
+IL_014a:  ldc.i4.2
+IL_014b:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_0150:  ldarg.0
+IL_0151:  ldc.i4.s   -5
+IL_0153:  dup
+IL_0154:  stloc.0
+IL_0155:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_015a:  leave.s    IL_01c0
+IL_015c:  ldarg.0
+IL_015d:  ldc.i4.m1
+IL_015e:  dup
+IL_015f:  stloc.0
+IL_0160:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0165:  ldarg.0
+IL_0166:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_016b:  pop
+IL_016c:  leave.s    IL_0199
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_016e:  stloc.s    V_4
+IL_0170:  ldarg.0
+IL_0171:  ldc.i4.s   -2
+IL_0173:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0178:  ldarg.0
+IL_0179:  ldc.i4.0
+IL_017a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_017f:  ldarg.0
+IL_0180:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0185:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_018a:  ldarg.0
+IL_018b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0190:  ldloc.s    V_4
+IL_0192:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_0197:  leave.s    IL_01cc
+}  // end handler
+IL_0199:  ldarg.0
+IL_019a:  ldc.i4.s   -2
+IL_019c:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_01a1:  ldarg.0
+IL_01a2:  ldc.i4.0
+IL_01a3:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_01a8:  ldarg.0
+IL_01a9:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_01ae:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_01b3:  ldarg.0
+IL_01b4:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01b9:  ldc.i4.0
+IL_01ba:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01bf:  ret
+IL_01c0:  ldarg.0
+IL_01c1:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01c6:  ldc.i4.1
+IL_01c7:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01cc:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_003d
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ldarg.0
+IL_003f:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_0044:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_0049:  ldloc.0
+IL_004a:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Producer>d__0'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Source>d__2'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ldarg.0
+IL_0007:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000c:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0011:  ldarg.0
+IL_0012:  ldarg.1
+IL_0013:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0018:  ldarg.0
+IL_0019:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001e:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0023:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Source>d__2' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -4
+IL_000a:  sub
+IL_000b:  switch     (
+IL_00b5,
+IL_0024,
+IL_0024,
+IL_0024,
+IL_007f)
+IL_0024:  ldarg.0
+IL_0025:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_002a:  brfalse.s  IL_0031
+IL_002c:  leave      IL_00f2
+IL_0031:  ldarg.0
+IL_0032:  ldc.i4.m1
+IL_0033:  dup
+IL_0034:  stloc.0
+IL_0035:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_003a:  ldc.i4.s   10
+IL_003c:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0041:  ldc.i4.0
+IL_0042:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Runtime]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0047:  stloc.2
+IL_0048:  ldloca.s   V_2
+IL_004a:  call       instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_004f:  stloc.1
+IL_0050:  ldloca.s   V_1
+IL_0052:  call       instance bool [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0057:  brtrue.s   IL_009b
+IL_0059:  ldarg.0
+IL_005a:  ldc.i4.0
+IL_005b:  dup
+IL_005c:  stloc.0
+IL_005d:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0062:  ldarg.0
+IL_0063:  ldloc.1
+IL_0064:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0069:  ldarg.0
+IL_006a:  stloc.3
+IL_006b:  ldarg.0
+IL_006c:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0071:  ldloca.s   V_1
+IL_0073:  ldloca.s   V_3
+IL_0075:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Source>d__2'>(!!0&,
+!!1&)
+IL_007a:  leave      IL_0125
+IL_007f:  ldarg.0
+IL_0080:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0085:  stloc.1
+IL_0086:  ldarg.0
+IL_0087:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_008c:  initobj    [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0092:  ldarg.0
+IL_0093:  ldc.i4.m1
+IL_0094:  dup
+IL_0095:  stloc.0
+IL_0096:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_009b:  ldloca.s   V_1
+IL_009d:  call       instance void [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00a2:  ldarg.0
+IL_00a3:  ldc.i4.1
+IL_00a4:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00a9:  ldarg.0
+IL_00aa:  ldc.i4.s   -4
+IL_00ac:  dup
+IL_00ad:  stloc.0
+IL_00ae:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00b3:  leave.s    IL_0119
+IL_00b5:  ldarg.0
+IL_00b6:  ldc.i4.m1
+IL_00b7:  dup
+IL_00b8:  stloc.0
+IL_00b9:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00be:  ldarg.0
+IL_00bf:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_00c4:  pop
+IL_00c5:  leave.s    IL_00f2
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00c7:  stloc.s    V_4
+IL_00c9:  ldarg.0
+IL_00ca:  ldc.i4.s   -2
+IL_00cc:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00d1:  ldarg.0
+IL_00d2:  ldc.i4.0
+IL_00d3:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00d8:  ldarg.0
+IL_00d9:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_00de:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_00e3:  ldarg.0
+IL_00e4:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_00e9:  ldloc.s    V_4
+IL_00eb:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_00f0:  leave.s    IL_0125
+}  // end handler
+IL_00f2:  ldarg.0
+IL_00f3:  ldc.i4.s   -2
+IL_00f5:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00fa:  ldarg.0
+IL_00fb:  ldc.i4.0
+IL_00fc:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0101:  ldarg.0
+IL_0102:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0107:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_010c:  ldarg.0
+IL_010d:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0112:  ldc.i4.0
+IL_0113:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_0118:  ret
+IL_0119:  ldarg.0
+IL_011a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_011f:  ldc.i4.1
+IL_0120:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_0125:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_003d
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Source>d__2'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.method public hidebysig instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Producer(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 50 72 6F 64 75 63 65 72 3E 64 5F 5F   // le+<Producer>d__
+30 00 00 )                                        // 0..
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_0007:  dup
+IL_0008:  ldarg.1
+IL_0009:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_000e:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitForeach(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 41 77 61 69 74 46 6F 72 65 61 63 68   // le+<AwaitForeach
+3E 64 5F 5F 31 00 00 )                            // >d__1..
+.maxstack  2
+.locals init (valuetype AsyncEnumerable/'<AwaitForeach>d__1' V_0)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldarg.1
+IL_000f:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitForeach>d__1'::context
+IL_0014:  ldloca.s   V_0
+IL_0016:  ldc.i4.m1
+IL_0017:  stfld      int32 AsyncEnumerable/'<AwaitForeach>d__1'::'<>1__state'
+IL_001c:  ldloca.s   V_0
+IL_001e:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0023:  ldloca.s   V_0
+IL_0025:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AsyncEnumerable/'<AwaitForeach>d__1'>(!!0&)
+IL_002a:  ldloca.s   V_0
+IL_002c:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitForeach>d__1'::'<>t__builder'
+IL_0031:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0036:  ret
+}
+.method private hidebysig static class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Source() cil managed
+{
+6C 65 2B 3C 53 6F 75 72 63 65 3E 64 5F 5F 32 00   // le+<Source>d__2.
+00 )
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_0007:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitUsing(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 41 77 61 69 74 55 73 69 6E 67 3E 64   // le+<AwaitUsing>d
+5F 5F 33 00 00 )                                  // __3..
+.maxstack  2
+.locals init (valuetype AsyncEnumerable/'<AwaitUsing>d__3' V_0)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldarg.1
+IL_000f:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<AwaitUsing>d__3'::context
+IL_0014:  ldloca.s   V_0
+IL_0016:  ldc.i4.m1
+IL_0017:  stfld      int32 AsyncEnumerable/'<AwaitUsing>d__3'::'<>1__state'
+IL_001c:  ldloca.s   V_0
+IL_001e:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0023:  ldloca.s   V_0
+IL_0025:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AsyncEnumerable/'<AwaitUsing>d__3'>(!!0&)
+IL_002a:  ldloca.s   V_0
+IL_002c:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AsyncEnumerable/'<AwaitUsing>d__3'::'<>t__builder'
+IL_0031:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0036:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ret
+}
+}

--- a/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Release.DotNet11_0.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAsyncEnumerable.Release.DotNet11_0.verified.txt
@@ -1,0 +1,1029 @@
+﻿.class public auto ansi beforefieldinit AsyncEnumerable
+extends [System.Runtime]System.Object
+{
+.class auto ansi sealed nested private beforefieldinit '<Producer>d__0'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private class [System.Threading]System.Threading.SynchronizationContext context
+.field public class [System.Threading]System.Threading.SynchronizationContext '<>3__context'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ldarg.0
+IL_0007:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000c:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0011:  ldarg.0
+IL_0012:  ldarg.1
+IL_0013:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0018:  ldarg.0
+IL_0019:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001e:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0023:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Producer>d__0' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -5
+IL_000a:  sub
+IL_000b:  switch     (
+IL_015c,
+IL_00cb,
+IL_002c,
+IL_002c,
+IL_002c,
+IL_0092,
+IL_0126)
+IL_002c:  ldarg.0
+IL_002d:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0032:  brfalse.s  IL_0039
+IL_0034:  leave      IL_0199
+IL_0039:  ldarg.0
+IL_003a:  ldc.i4.m1
+IL_003b:  dup
+IL_003c:  stloc.0
+IL_003d:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0042:  ldarg.0
+IL_0043:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_0048:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_004d:  ldc.i4.s   10
+IL_004f:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0054:  ldc.i4.0
+IL_0055:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_005a:  stloc.2
+IL_005b:  ldloca.s   V_2
+IL_005d:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0062:  stloc.1
+IL_0063:  ldloca.s   V_1
+IL_0065:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_006a:  brtrue.s   IL_00ae
+IL_006c:  ldarg.0
+IL_006d:  ldc.i4.0
+IL_006e:  dup
+IL_006f:  stloc.0
+IL_0070:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0075:  ldarg.0
+IL_0076:  ldloc.1
+IL_0077:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_007c:  ldarg.0
+IL_007d:  stloc.3
+IL_007e:  ldarg.0
+IL_007f:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0084:  ldloca.s   V_1
+IL_0086:  ldloca.s   V_3
+IL_0088:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_008d:  leave      IL_01cc
+IL_0092:  ldarg.0
+IL_0093:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0098:  stloc.1
+IL_0099:  ldarg.0
+IL_009a:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_009f:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_00a5:  ldarg.0
+IL_00a6:  ldc.i4.m1
+IL_00a7:  dup
+IL_00a8:  stloc.0
+IL_00a9:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00ae:  ldloca.s   V_1
+IL_00b0:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00b5:  ldarg.0
+IL_00b6:  ldc.i4.1
+IL_00b7:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_00bc:  ldarg.0
+IL_00bd:  ldc.i4.s   -4
+IL_00bf:  dup
+IL_00c0:  stloc.0
+IL_00c1:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00c6:  leave      IL_01c0
+IL_00cb:  ldarg.0
+IL_00cc:  ldc.i4.m1
+IL_00cd:  dup
+IL_00ce:  stloc.0
+IL_00cf:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_00d4:  ldarg.0
+IL_00d5:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_00da:  brfalse.s  IL_00e1
+IL_00dc:  leave      IL_0199
+IL_00e1:  ldc.i4.s   10
+IL_00e3:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_00e8:  ldc.i4.0
+IL_00e9:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_00ee:  stloc.2
+IL_00ef:  ldloca.s   V_2
+IL_00f1:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_00f6:  stloc.1
+IL_00f7:  ldloca.s   V_1
+IL_00f9:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_00fe:  brtrue.s   IL_0142
+IL_0100:  ldarg.0
+IL_0101:  ldc.i4.1
+IL_0102:  dup
+IL_0103:  stloc.0
+IL_0104:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0109:  ldarg.0
+IL_010a:  ldloc.1
+IL_010b:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0110:  ldarg.0
+IL_0111:  stloc.3
+IL_0112:  ldarg.0
+IL_0113:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0118:  ldloca.s   V_1
+IL_011a:  ldloca.s   V_3
+IL_011c:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Producer>d__0'>(!!0&,
+!!1&)
+IL_0121:  leave      IL_01cc
+IL_0126:  ldarg.0
+IL_0127:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_012c:  stloc.1
+IL_012d:  ldarg.0
+IL_012e:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Producer>d__0'::'<>u__1'
+IL_0133:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0139:  ldarg.0
+IL_013a:  ldc.i4.m1
+IL_013b:  dup
+IL_013c:  stloc.0
+IL_013d:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0142:  ldloca.s   V_1
+IL_0144:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_0149:  ldarg.0
+IL_014a:  ldc.i4.2
+IL_014b:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_0150:  ldarg.0
+IL_0151:  ldc.i4.s   -5
+IL_0153:  dup
+IL_0154:  stloc.0
+IL_0155:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_015a:  leave.s    IL_01c0
+IL_015c:  ldarg.0
+IL_015d:  ldc.i4.m1
+IL_015e:  dup
+IL_015f:  stloc.0
+IL_0160:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0165:  ldarg.0
+IL_0166:  ldfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_016b:  pop
+IL_016c:  leave.s    IL_0199
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_016e:  stloc.s    V_4
+IL_0170:  ldarg.0
+IL_0171:  ldc.i4.s   -2
+IL_0173:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0178:  ldarg.0
+IL_0179:  ldc.i4.0
+IL_017a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_017f:  ldarg.0
+IL_0180:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0185:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_018a:  ldarg.0
+IL_018b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0190:  ldloc.s    V_4
+IL_0192:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_0197:  leave.s    IL_01cc
+}  // end handler
+IL_0199:  ldarg.0
+IL_019a:  ldc.i4.s   -2
+IL_019c:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_01a1:  ldarg.0
+IL_01a2:  ldc.i4.0
+IL_01a3:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_01a8:  ldarg.0
+IL_01a9:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_01ae:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_01b3:  ldarg.0
+IL_01b4:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01b9:  ldc.i4.0
+IL_01ba:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01bf:  ret
+IL_01c0:  ldarg.0
+IL_01c1:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_01c6:  ldc.i4.1
+IL_01c7:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_01cc:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_003d
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ldarg.0
+IL_003f:  ldfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_0044:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::context
+IL_0049:  ldloc.0
+IL_004a:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Producer>d__0' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Producer>d__0'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Producer>d__0'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Producer>d__0'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Producer>d__0'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Producer>d__0'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Producer>d__0'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.class auto ansi sealed nested private beforefieldinit '<Source>d__2'
+extends [System.Runtime]System.Object
+implements class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>,
+class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>,
+[System.Runtime]System.IAsyncDisposable,
+class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>,
+[System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+[System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+.interfaceimpl type class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+.interfaceimpl type [System.Runtime]System.IAsyncDisposable
+.interfaceimpl type class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>
+.interfaceimpl type [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource
+.interfaceimpl type [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder '<>t__builder'
+.field public valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> '<>v__promiseOfValueOrEnd'
+.field private int32 '<>2__current'
+.field private bool '<>w__disposeMode'
+.field private int32 '<>l__initialThreadId'
+.field private valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method public hidebysig specialname rtspecialname
+instance void  .ctor(int32 '<>1__state') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ldarg.0
+IL_0007:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_000c:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0011:  ldarg.0
+IL_0012:  ldarg.1
+IL_0013:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0018:  ldarg.0
+IL_0019:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_001e:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0023:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class AsyncEnumerable/'<Source>d__2' V_3,
+class [System.Runtime]System.Exception V_4)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  ldc.i4.s   -4
+IL_000a:  sub
+IL_000b:  switch     (
+IL_00b5,
+IL_0024,
+IL_0024,
+IL_0024,
+IL_007f)
+IL_0024:  ldarg.0
+IL_0025:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_002a:  brfalse.s  IL_0031
+IL_002c:  leave      IL_00f2
+IL_0031:  ldarg.0
+IL_0032:  ldc.i4.m1
+IL_0033:  dup
+IL_0034:  stloc.0
+IL_0035:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_003a:  ldc.i4.s   10
+IL_003c:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0041:  ldc.i4.0
+IL_0042:  callvirt   instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Runtime]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0047:  stloc.2
+IL_0048:  ldloca.s   V_2
+IL_004a:  call       instance valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_004f:  stloc.1
+IL_0050:  ldloca.s   V_1
+IL_0052:  call       instance bool [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0057:  brtrue.s   IL_009b
+IL_0059:  ldarg.0
+IL_005a:  ldc.i4.0
+IL_005b:  dup
+IL_005c:  stloc.0
+IL_005d:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0062:  ldarg.0
+IL_0063:  ldloc.1
+IL_0064:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0069:  ldarg.0
+IL_006a:  stloc.3
+IL_006b:  ldarg.0
+IL_006c:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0071:  ldloca.s   V_1
+IL_0073:  ldloca.s   V_3
+IL_0075:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,class AsyncEnumerable/'<Source>d__2'>(!!0&,
+!!1&)
+IL_007a:  leave      IL_0125
+IL_007f:  ldarg.0
+IL_0080:  ldfld      valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_0085:  stloc.1
+IL_0086:  ldarg.0
+IL_0087:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AsyncEnumerable/'<Source>d__2'::'<>u__1'
+IL_008c:  initobj    [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0092:  ldarg.0
+IL_0093:  ldc.i4.m1
+IL_0094:  dup
+IL_0095:  stloc.0
+IL_0096:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_009b:  ldloca.s   V_1
+IL_009d:  call       instance void [System.Runtime]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_00a2:  ldarg.0
+IL_00a3:  ldc.i4.1
+IL_00a4:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00a9:  ldarg.0
+IL_00aa:  ldc.i4.s   -4
+IL_00ac:  dup
+IL_00ad:  stloc.0
+IL_00ae:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00b3:  leave.s    IL_0119
+IL_00b5:  ldarg.0
+IL_00b6:  ldc.i4.m1
+IL_00b7:  dup
+IL_00b8:  stloc.0
+IL_00b9:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00be:  ldarg.0
+IL_00bf:  ldfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_00c4:  pop
+IL_00c5:  leave.s    IL_00f2
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_00c7:  stloc.s    V_4
+IL_00c9:  ldarg.0
+IL_00ca:  ldc.i4.s   -2
+IL_00cc:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00d1:  ldarg.0
+IL_00d2:  ldc.i4.0
+IL_00d3:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_00d8:  ldarg.0
+IL_00d9:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_00de:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_00e3:  ldarg.0
+IL_00e4:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_00e9:  ldloc.s    V_4
+IL_00eb:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetException(class [System.Runtime]System.Exception)
+IL_00f0:  leave.s    IL_0125
+}  // end handler
+IL_00f2:  ldarg.0
+IL_00f3:  ldc.i4.s   -2
+IL_00f5:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_00fa:  ldarg.0
+IL_00fb:  ldc.i4.0
+IL_00fc:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0101:  ldarg.0
+IL_0102:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0107:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Complete()
+IL_010c:  ldarg.0
+IL_010d:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0112:  ldc.i4.0
+IL_0113:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_0118:  ret
+IL_0119:  ldarg.0
+IL_011a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_011f:  ldc.i4.1
+IL_0120:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::SetResult(!0)
+IL_0125:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ret
+}
+.method private hidebysig newslot virtual final
+instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>
+'System.Collections.Generic.IAsyncEnumerable<System.Int32>.GetAsyncEnumerator'([opt] valuetype [System.Runtime]System.Threading.CancellationToken cancellationToken) cil managed
+{
+.param [1] = nullref
+.override  method instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0035
+IL_000a:  ldarg.0
+IL_000b:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>l__initialThreadId'
+IL_0010:  call       int32 [System.Runtime]System.Environment::get_CurrentManagedThreadId()
+IL_0015:  bne.un.s   IL_0035
+IL_0017:  ldarg.0
+IL_0018:  ldc.i4.s   -3
+IL_001a:  stfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_001f:  ldarg.0
+IL_0020:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::Create()
+IL_0025:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_002a:  ldarg.0
+IL_002b:  ldc.i4.0
+IL_002c:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_0031:  ldarg.0
+IL_0032:  stloc.0
+IL_0033:  br.s       IL_003d
+IL_0035:  ldc.i4.s   -3
+IL_0037:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_003c:  stloc.0
+IL_003d:  ldloc.0
+IL_003e:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+'System.Collections.Generic.IAsyncEnumerator<System.Int32>.MoveNextAsync'() cil managed
+{
+.param [0]
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+int16 V_1,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> V_2)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.s   -2
+IL_0008:  bne.un.s   IL_0014
+IL_000a:  ldloca.s   V_2
+IL_000c:  initobj    valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>
+IL_0012:  ldloc.2
+IL_0013:  ret
+IL_0014:  ldarg.0
+IL_0015:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_001a:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_001f:  ldarg.0
+IL_0020:  stloc.0
+IL_0021:  ldarg.0
+IL_0022:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_0027:  ldloca.s   V_0
+IL_0029:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_002e:  ldarg.0
+IL_002f:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0034:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0039:  stloc.1
+IL_003a:  ldarg.0
+IL_003b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0040:  ldloc.1
+IL_0041:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_0046:  ldc.i4.1
+IL_0047:  bne.un.s   IL_005b
+IL_0049:  ldarg.0
+IL_004a:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004f:  ldloc.1
+IL_0050:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_0055:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(!0)
+IL_005a:  ret
+IL_005b:  ldarg.0
+IL_005c:  ldloc.1
+IL_005d:  newobj     instance void valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool>::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<!0>,
+int16)
+IL_0062:  ret
+}
+.method private hidebysig newslot specialname virtual final
+instance int32  'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'() cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>2__current'
+IL_0006:  ret
+}
+.method private hidebysig newslot virtual final
+instance bool  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult'(int16 token) cil managed
+{
+.override  method instance !0 class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetResult(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetStatus'(int16 token) cil managed
+{
+.override  method instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::GetStatus(int16)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  'System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.OnCompleted'(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override  method instance void class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.GetResult(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetResult
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance !0 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetResult(int16)
+IL_000c:  pop
+IL_000d:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus
+System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(int16 token) cil managed
+{
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::GetStatus
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  call       instance valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceStatus valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::GetStatus(int16)
+IL_000c:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(class [System.Runtime]System.Action`1<object> continuation,
+object state,
+int16 token,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags 'flags') cil managed
+{
+.param [1]
+.param [2]
+.override [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource::OnCompleted
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0006:  ldarg.1
+IL_0007:  ldarg.2
+IL_0008:  ldarg.3
+IL_0009:  ldarg.s    'flags'
+IL_000b:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::OnCompleted(class [System.Runtime]System.Action`1<object>,
+object,
+int16,
+valuetype [System.Runtime]System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)
+IL_0010:  ret
+}
+.method private hidebysig newslot virtual final
+instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask
+System.IAsyncDisposable.DisposeAsync() cil managed
+{
+.override [System.Runtime]System.IAsyncDisposable::DisposeAsync
+.maxstack  2
+.locals init (class AsyncEnumerable/'<Source>d__2' V_0,
+valuetype [System.Runtime]System.Threading.Tasks.ValueTask V_1)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0006:  ldc.i4.m1
+IL_0007:  blt.s      IL_000f
+IL_0009:  newobj     instance void [System.Runtime]System.NotSupportedException::.ctor()
+IL_000e:  throw
+IL_000f:  ldarg.0
+IL_0010:  ldfld      int32 AsyncEnumerable/'<Source>d__2'::'<>1__state'
+IL_0015:  ldc.i4.s   -2
+IL_0017:  bne.un.s   IL_0023
+IL_0019:  ldloca.s   V_1
+IL_001b:  initobj    [System.Runtime]System.Threading.Tasks.ValueTask
+IL_0021:  ldloc.1
+IL_0022:  ret
+IL_0023:  ldarg.0
+IL_0024:  ldc.i4.1
+IL_0025:  stfld      bool AsyncEnumerable/'<Source>d__2'::'<>w__disposeMode'
+IL_002a:  ldarg.0
+IL_002b:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_0030:  call       instance void valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::Reset()
+IL_0035:  ldarg.0
+IL_0036:  stloc.0
+IL_0037:  ldarg.0
+IL_0038:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder AsyncEnumerable/'<Source>d__2'::'<>t__builder'
+IL_003d:  ldloca.s   V_0
+IL_003f:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncIteratorMethodBuilder::MoveNext<class AsyncEnumerable/'<Source>d__2'>(!!0&)
+IL_0044:  ldarg.0
+IL_0045:  ldarg.0
+IL_0046:  ldflda     valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool> AsyncEnumerable/'<Source>d__2'::'<>v__promiseOfValueOrEnd'
+IL_004b:  call       instance int16 valuetype [System.Runtime]System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore`1<bool>::get_Version()
+IL_0050:  newobj     instance void [System.Runtime]System.Threading.Tasks.ValueTask::.ctor(class [System.Runtime]System.Threading.Tasks.Sources.IValueTaskSource,
+int16)
+IL_0055:  ret
+}
+.property instance int32 'System.Collections.Generic.IAsyncEnumerator<System.Int32>.Current'()
+{
+.get instance int32 AsyncEnumerable/'<Source>d__2'::'System.Collections.Generic.IAsyncEnumerator<System.Int32>.get_Current'()
+}
+}
+.method public hidebysig instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Producer(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+6C 65 2B 3C 50 72 6F 64 75 63 65 72 3E 64 5F 5F   // le+<Producer>d__
+30 00 00 )                                        // 0..
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Producer>d__0'::.ctor(int32)
+IL_0007:  dup
+IL_0008:  ldarg.1
+IL_0009:  stfld      class [System.Threading]System.Threading.SynchronizationContext AsyncEnumerable/'<Producer>d__0'::'<>3__context'
+IL_000e:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitForeach(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+.maxstack  2
+.locals init (class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32> V_0,
+valuetype [System.Runtime]System.Threading.CancellationToken V_1,
+object V_2,
+valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<bool> V_3,
+valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask V_4)
+IL_0000:  ldarg.1
+IL_0001:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0006:  call       class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32> AsyncEnumerable::Source()
+IL_000b:  ldloca.s   V_1
+IL_000d:  initobj    [System.Runtime]System.Threading.CancellationToken
+IL_0013:  ldloc.1
+IL_0014:  callvirt   instance class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<!0> class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>::GetAsyncEnumerator(valuetype [System.Runtime]System.Threading.CancellationToken)
+IL_0019:  stloc.0
+IL_001a:  ldnull
+IL_001b:  stloc.2
+.try
+{
+IL_001c:  br.s       IL_0025
+IL_001e:  ldloc.0
+IL_001f:  callvirt   instance !0 class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::get_Current()
+IL_0024:  pop
+IL_0025:  ldloc.0
+IL_0026:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask`1<bool> class [System.Runtime]System.Collections.Generic.IAsyncEnumerator`1<int32>::MoveNextAsync()
+IL_002b:  stloc.3
+IL_002c:  ldloca.s   V_3
+IL_002e:  ldc.i4.0
+IL_002f:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!0> valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask`1<bool>::ConfigureAwait(bool)
+IL_0034:  call       !!0 [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await<bool>(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1<!!0>)
+IL_0039:  brtrue.s   IL_001e
+IL_003b:  leave.s    IL_0040
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_003d:  stloc.2
+IL_003e:  leave.s    IL_0040
+}  // end handler
+IL_0040:  ldloc.0
+IL_0041:  brfalse.s  IL_0058
+IL_0043:  ldloc.0
+IL_0044:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask [System.Runtime]System.IAsyncDisposable::DisposeAsync()
+IL_0049:  stloc.s    V_4
+IL_004b:  ldloca.s   V_4
+IL_004d:  ldc.i4.0
+IL_004e:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0053:  call       void [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable)
+IL_0058:  ldloc.2
+IL_0059:  brfalse.s  IL_0070
+IL_005b:  ldloc.2
+IL_005c:  isinst     [System.Runtime]System.Exception
+IL_0061:  dup
+IL_0062:  brtrue.s   IL_0066
+IL_0064:  ldloc.2
+IL_0065:  throw
+IL_0066:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_006b:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_0070:  ret
+}
+.method private hidebysig static class [System.Runtime]System.Collections.Generic.IAsyncEnumerable`1<int32>
+Source() cil managed
+{
+6C 65 2B 3C 53 6F 75 72 63 65 3E 64 5F 5F 32 00   // le+<Source>d__2.
+00 )
+.maxstack  8
+IL_0000:  ldc.i4.s   -2
+IL_0002:  newobj     instance void AsyncEnumerable/'<Source>d__2'::.ctor(int32)
+IL_0007:  ret
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+AwaitUsing(class [System.Threading]System.Threading.SynchronizationContext context) cil managed
+{
+.maxstack  2
+.locals init (class AsyncDisposable V_0,
+object V_1,
+valuetype [System.Private.CoreLib]System.Threading.Tasks.ValueTask V_2)
+IL_0000:  ldarg.1
+IL_0001:  call       void [System.Threading]System.Threading.SynchronizationContext::SetSynchronizationContext(class [System.Threading]System.Threading.SynchronizationContext)
+IL_0006:  newobj     instance void AsyncDisposable::.ctor()
+IL_000b:  stloc.0
+IL_000c:  ldnull
+IL_000d:  stloc.1
+.try
+{
+IL_000e:  leave.s    IL_0013
+}  // end .try
+catch [System.Runtime]System.Object
+{
+IL_0010:  stloc.1
+IL_0011:  leave.s    IL_0013
+}  // end handler
+IL_0013:  ldloc.0
+IL_0014:  brfalse.s  IL_002a
+IL_0016:  ldloc.0
+IL_0017:  callvirt   instance valuetype [System.Runtime]System.Threading.Tasks.ValueTask AsyncDisposable::DisposeAsync()
+IL_001c:  stloc.2
+IL_001d:  ldloca.s   V_2
+IL_001f:  ldc.i4.0
+IL_0020:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.ValueTask::ConfigureAwait(bool)
+IL_0025:  call       void [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable)
+IL_002a:  ldloc.1
+IL_002b:  brfalse.s  IL_0042
+IL_002d:  ldloc.1
+IL_002e:  isinst     [System.Runtime]System.Exception
+IL_0033:  dup
+IL_0034:  brtrue.s   IL_0038
+IL_0036:  ldloc.1
+IL_0037:  throw
+IL_0038:  call       class [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Capture(class [System.Runtime]System.Exception)
+IL_003d:  callvirt   instance void [System.Runtime]System.Runtime.ExceptionServices.ExceptionDispatchInfo::Throw()
+IL_0042:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ret
+}
+}

--- a/Tests/ModuleWeaverTests.DecompileAwaitTernary.Release.DotNet10_0.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAwaitTernary.Release.DotNet10_0.verified.txt
@@ -1,0 +1,143 @@
+﻿.class public auto ansi beforefieldinit AwaitTernary
+extends [System.Runtime]System.Object
+{
+.class auto ansi sealed nested private beforefieldinit '<Method>d__0'
+extends [System.Runtime]System.ValueType
+implements [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public string 'value'
+.field private valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class [System.Runtime]System.Exception V_3)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0062
+IL_000a:  ldarg.0
+IL_000b:  ldfld      string AwaitTernary/'<Method>d__0'::'value'
+IL_0010:  ldstr      "anyValue"
+IL_0015:  call       bool [System.Runtime]System.String::op_Equality(string,
+string)
+IL_001a:  brtrue.s   IL_0024
+IL_001c:  ldc.i4.2
+IL_001d:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0022:  br.s       IL_002a
+IL_0024:  ldc.i4.1
+IL_0025:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_002a:  ldc.i4.0
+IL_002b:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0030:  stloc.2
+IL_0031:  ldloca.s   V_2
+IL_0033:  call       instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0038:  stloc.1
+IL_0039:  ldloca.s   V_1
+IL_003b:  call       instance bool [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0040:  brtrue.s   IL_007e
+IL_0042:  ldarg.0
+IL_0043:  ldc.i4.0
+IL_0044:  dup
+IL_0045:  stloc.0
+IL_0046:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_004b:  ldarg.0
+IL_004c:  ldloc.1
+IL_004d:  stfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AwaitTernary/'<Method>d__0'::'<>u__1'
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0058:  ldloca.s   V_1
+IL_005a:  ldarg.0
+IL_005b:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,valuetype AwaitTernary/'<Method>d__0'>(!!0&,
+!!1&)
+IL_0060:  leave.s    IL_00b1
+IL_0062:  ldarg.0
+IL_0063:  ldfld      valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AwaitTernary/'<Method>d__0'::'<>u__1'
+IL_0068:  stloc.1
+IL_0069:  ldarg.0
+IL_006a:  ldflda     valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AwaitTernary/'<Method>d__0'::'<>u__1'
+IL_006f:  initobj    [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0075:  ldarg.0
+IL_0076:  ldc.i4.m1
+IL_0077:  dup
+IL_0078:  stloc.0
+IL_0079:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_007e:  ldloca.s   V_1
+IL_0080:  call       instance void [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_0085:  leave.s    IL_009e
+}  // end .try
+catch [System.Runtime]System.Exception
+{
+IL_0087:  stloc.3
+IL_0088:  ldarg.0
+IL_0089:  ldc.i4.s   -2
+IL_008b:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_0090:  ldarg.0
+IL_0091:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0096:  ldloc.3
+IL_0097:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [System.Runtime]System.Exception)
+IL_009c:  leave.s    IL_00b1
+}  // end handler
+IL_009e:  ldarg.0
+IL_009f:  ldc.i4.s   -2
+IL_00a1:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_00a6:  ldarg.0
+IL_00a7:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_00ac:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00b1:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.param [1]
+.override [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [System.Runtime]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Method(string 'value') cil managed
+{
+3C 4D 65 74 68 6F 64 3E 64 5F 5F 30 00 00 )       // <Method>d__0..
+.maxstack  2
+.locals init (valuetype AwaitTernary/'<Method>d__0' V_0)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldarg.1
+IL_000f:  stfld      string AwaitTernary/'<Method>d__0'::'value'
+IL_0014:  ldloca.s   V_0
+IL_0016:  ldc.i4.m1
+IL_0017:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_001c:  ldloca.s   V_0
+IL_001e:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0023:  ldloca.s   V_0
+IL_0025:  call       instance void [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AwaitTernary/'<Method>d__0'>(!!0&)
+IL_002a:  ldloca.s   V_0
+IL_002c:  ldflda     valuetype [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0031:  call       instance class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0036:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ret
+}
+}

--- a/Tests/ModuleWeaverTests.DecompileAwaitTernary.Release.DotNet11_0.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAwaitTernary.Release.DotNet11_0.verified.txt
@@ -1,0 +1,31 @@
+﻿.class public auto ansi beforefieldinit AwaitTernary
+extends [System.Runtime]System.Object
+{
+.method public hidebysig instance class [System.Runtime]System.Threading.Tasks.Task
+Method(string 'value') cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.1
+IL_0001:  ldstr      "anyValue"
+IL_0006:  call       bool [System.Runtime]System.String::op_Equality(string,
+string)
+IL_000b:  brtrue.s   IL_0015
+IL_000d:  ldc.i4.2
+IL_000e:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_0013:  br.s       IL_001b
+IL_0015:  ldc.i4.1
+IL_0016:  call       class [System.Runtime]System.Threading.Tasks.Task [System.Runtime]System.Threading.Tasks.Task::Delay(int32)
+IL_001b:  ldc.i4.0
+IL_001c:  callvirt   instance valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [System.Private.CoreLib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0021:  call       void [System.Private.CoreLib]System.Runtime.CompilerServices.AsyncHelpers::Await(valuetype [System.Private.CoreLib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable)
+IL_0026:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+IL_0006:  ret
+}
+}

--- a/Tests/ModuleWeaverTests.DecompileAwaitTernary.Release.Net4_7.verified.txt
+++ b/Tests/ModuleWeaverTests.DecompileAwaitTernary.Release.Net4_7.verified.txt
@@ -1,0 +1,143 @@
+﻿.class public auto ansi beforefieldinit AwaitTernary
+extends [mscorlib]System.Object
+{
+.class auto ansi sealed nested private beforefieldinit '<Method>d__0'
+extends [mscorlib]System.ValueType
+implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
+{
+.field public int32 '<>1__state'
+.field public valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder '<>t__builder'
+.field public string 'value'
+.field private valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter '<>u__1'
+.method private hidebysig newslot virtual final
+instance void  MoveNext() cil managed
+{
+.override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
+.maxstack  3
+.locals init (int32 V_0,
+valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter V_1,
+valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable V_2,
+class [mscorlib]System.Exception V_3)
+IL_0000:  ldarg.0
+IL_0001:  ldfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_0006:  stloc.0
+.try
+{
+IL_0007:  ldloc.0
+IL_0008:  brfalse.s  IL_0062
+IL_000a:  ldarg.0
+IL_000b:  ldfld      string AwaitTernary/'<Method>d__0'::'value'
+IL_0010:  ldstr      "anyValue"
+IL_0015:  call       bool [mscorlib]System.String::op_Equality(string,
+string)
+IL_001a:  brtrue.s   IL_0024
+IL_001c:  ldc.i4.2
+IL_001d:  call       class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Threading.Tasks.Task::Delay(int32)
+IL_0022:  br.s       IL_002a
+IL_0024:  ldc.i4.1
+IL_0025:  call       class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Threading.Tasks.Task::Delay(int32)
+IL_002a:  ldc.i4.0
+IL_002b:  callvirt   instance valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable [mscorlib]System.Threading.Tasks.Task::ConfigureAwait(bool)
+IL_0030:  stloc.2
+IL_0031:  ldloca.s   V_2
+IL_0033:  call       instance valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable::GetAwaiter()
+IL_0038:  stloc.1
+IL_0039:  ldloca.s   V_1
+IL_003b:  call       instance bool [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::get_IsCompleted()
+IL_0040:  brtrue.s   IL_007e
+IL_0042:  ldarg.0
+IL_0043:  ldc.i4.0
+IL_0044:  dup
+IL_0045:  stloc.0
+IL_0046:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_004b:  ldarg.0
+IL_004c:  ldloc.1
+IL_004d:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AwaitTernary/'<Method>d__0'::'<>u__1'
+IL_0052:  ldarg.0
+IL_0053:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0058:  ldloca.s   V_1
+IL_005a:  ldarg.0
+IL_005b:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter,valuetype AwaitTernary/'<Method>d__0'>(!!0&,
+!!1&)
+IL_0060:  leave.s    IL_00b1
+IL_0062:  ldarg.0
+IL_0063:  ldfld      valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AwaitTernary/'<Method>d__0'::'<>u__1'
+IL_0068:  stloc.1
+IL_0069:  ldarg.0
+IL_006a:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter AwaitTernary/'<Method>d__0'::'<>u__1'
+IL_006f:  initobj    [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter
+IL_0075:  ldarg.0
+IL_0076:  ldc.i4.m1
+IL_0077:  dup
+IL_0078:  stloc.0
+IL_0079:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_007e:  ldloca.s   V_1
+IL_0080:  call       instance void [mscorlib]System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter::GetResult()
+IL_0085:  leave.s    IL_009e
+}  // end .try
+catch [mscorlib]System.Exception
+{
+IL_0087:  stloc.3
+IL_0088:  ldarg.0
+IL_0089:  ldc.i4.s   -2
+IL_008b:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_0090:  ldarg.0
+IL_0091:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0096:  ldloc.3
+IL_0097:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [mscorlib]System.Exception)
+IL_009c:  leave.s    IL_00b1
+}  // end handler
+IL_009e:  ldarg.0
+IL_009f:  ldc.i4.s   -2
+IL_00a1:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_00a6:  ldarg.0
+IL_00a7:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_00ac:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetResult()
+IL_00b1:  ret
+}
+.method private hidebysig newslot virtual final
+instance void  SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine stateMachine) cil managed
+{
+.override [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0006:  ldarg.1
+IL_0007:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
+IL_000c:  ret
+}
+}
+.method public hidebysig instance class [mscorlib]System.Threading.Tasks.Task
+Method(string 'value') cil managed
+{
+.custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 01 00 00 )
+3C 4D 65 74 68 6F 64 3E 64 5F 5F 30 00 00 )       // <Method>d__0..
+.maxstack  2
+.locals init (valuetype AwaitTernary/'<Method>d__0' V_0)
+IL_0000:  ldloca.s   V_0
+IL_0002:  call       valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
+IL_0007:  stfld      valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_000c:  ldloca.s   V_0
+IL_000e:  ldarg.1
+IL_000f:  stfld      string AwaitTernary/'<Method>d__0'::'value'
+IL_0014:  ldloca.s   V_0
+IL_0016:  ldc.i4.m1
+IL_0017:  stfld      int32 AwaitTernary/'<Method>d__0'::'<>1__state'
+IL_001c:  ldloca.s   V_0
+IL_001e:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0023:  ldloca.s   V_0
+IL_0025:  call       instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype AwaitTernary/'<Method>d__0'>(!!0&)
+IL_002a:  ldloca.s   V_0
+IL_002c:  ldflda     valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder AwaitTernary/'<Method>d__0'::'<>t__builder'
+IL_0031:  call       instance class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+IL_0036:  ret
+}
+.method public hidebysig specialname rtspecialname
+instance void  .ctor() cil managed
+{
+.maxstack  8
+IL_0000:  ldarg.0
+IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+IL_0006:  ret
+}
+}

--- a/Tests/VerifyTest.cs
+++ b/Tests/VerifyTest.cs
@@ -45,6 +45,15 @@ public partial class ModuleWeaverTests
         return Verify(decompile, GetSettings());
     }
 
+#if NET
+    [Fact]
+    public Task DecompileAsyncEnumerable()
+    {
+        var decompile = Ildasm.Decompile(testResult.AssemblyPath, "AsyncEnumerable");
+        return Verify(decompile, GetSettings());
+    }
+#endif
+
     VerifySettings GetSettings()
     {
         var settings = new VerifySettings();


### PR DESCRIPTION
Async iterators (async IAsyncEnumerable<T> with yield) are lowered with AsyncIteratorStateMachineAttribute rather than AsyncStateMachineAttribute, so ProcessType skipped them and their awaits kept resuming on the captured context. Recognise both attributes in GetAsyncStateMachineKind/Type so the iterator body is woven like any other state machine. Adds behavioural tests for the iterator producer plus the await foreach / await using consumer paths, and an IL snapshot of the woven types.
